### PR TITLE
feat(agent): local-first tool registry with network/credential gating

### DIFF
--- a/src/lib/agent/tool-registry.test.ts
+++ b/src/lib/agent/tool-registry.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+
+import {
+  BUILTIN_TOOLS,
+  LLM_API_KEY_STORAGE_KEY,
+  ToolRegistry,
+  createDefaultRegistry,
+  hasConfiguredCredential,
+  isSensitiveKey,
+} from './tool-registry'
+import { secureStorage } from '@/lib/native/secure-storage'
+
+describe('isSensitiveKey', () => {
+  it.each([
+    '__llm_runtime_api_key__',
+    '__llm_runtime_api_key__:openai',
+    'openai_api_key',
+    'OPENAI_API_KEY',
+    'github_token',
+    'session-secret',
+    'user_password',
+  ])('flags %s as sensitive', (key) => {
+    expect(isSensitiveKey(key)).toBe(true)
+  })
+
+  it.each(['active-tab', 'theme', 'last_query', 'foo', 'cache:doc:123'])(
+    'leaves %s alone',
+    (key) => {
+      expect(isSensitiveKey(key)).toBe(false)
+    },
+  )
+})
+
+describe('ToolRegistry', () => {
+  let reg: ToolRegistry
+
+  beforeEach(() => {
+    reg = new ToolRegistry()
+  })
+
+  it('registers and retrieves a tool', () => {
+    reg.register({
+      name: 'echo',
+      description: 'Echo input.',
+      inputSchema: z.object({ msg: z.string() }).strict(),
+      execute: ({ msg }) => ({ msg }),
+    })
+    expect(reg.has('echo')).toBe(true)
+    expect(reg.get('echo')?.name).toBe('echo')
+    expect(reg.list()).toHaveLength(1)
+  })
+
+  it('refuses duplicate registration', () => {
+    reg.register({
+      name: 'dup',
+      description: 'first',
+      inputSchema: z.object({}).strict(),
+      execute: () => null,
+    })
+    expect(() =>
+      reg.register({
+        name: 'dup',
+        description: 'second',
+        inputSchema: z.object({}).strict(),
+        execute: () => null,
+      }),
+    ).toThrow(/already registered/)
+  })
+
+  it('upsert replaces an existing definition', () => {
+    reg.register({
+      name: 't',
+      description: 'first',
+      inputSchema: z.object({}).strict(),
+      execute: () => 'first',
+    })
+    reg.upsert({
+      name: 't',
+      description: 'second',
+      inputSchema: z.object({}).strict(),
+      execute: () => 'second',
+    })
+    expect(reg.get('t')?.description).toBe('second')
+  })
+
+  it('unregister removes a tool', () => {
+    reg.register({
+      name: 'gone',
+      description: '',
+      inputSchema: z.object({}).strict(),
+      execute: () => null,
+    })
+    expect(reg.unregister('gone')).toBe(true)
+    expect(reg.unregister('gone')).toBe(false)
+    expect(reg.has('gone')).toBe(false)
+  })
+})
+
+describe('createDefaultRegistry — built-in tools', () => {
+  it('seeds three local-first tools', () => {
+    const reg = createDefaultRegistry()
+    expect(reg.list().map((t) => t.name).sort()).toEqual([
+      'currentTime',
+      'kvStoreLookup',
+      'mathEval',
+    ])
+  })
+
+  it('all built-ins are zero-network', () => {
+    for (const def of BUILTIN_TOOLS) {
+      expect(def.requiresNetwork ?? false).toBe(false)
+      expect(def.requiresCredential ?? false).toBe(false)
+    }
+  })
+
+  describe('currentTime', () => {
+    it('returns ISO timestamp + IANA zone', async () => {
+      const reg = createDefaultRegistry()
+      const def = reg.get('currentTime')
+      expect(def).toBeDefined()
+      const result = (await def!.execute({}, {})) as {
+        iso: string
+        timestamp: number
+        timeZone: string
+      }
+      expect(result.iso).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+      expect(typeof result.timestamp).toBe('number')
+      expect(typeof result.timeZone).toBe('string')
+    })
+  })
+
+  describe('mathEval', () => {
+    const cases: Array<[string, number]> = [
+      ['1 + 2', 3],
+      ['(2 + 3) * 4', 20],
+      ['10 / 4', 2.5],
+      ['-5 + 8', 3],
+      ['2.5 * 4', 10],
+      ['((1+2)*(3+4))', 21],
+    ]
+    it.each(cases)('evaluates %s = %s', async (expr, expected) => {
+      const def = createDefaultRegistry().get('mathEval')!
+      const result = (await def.execute(
+        { expression: expr },
+        {},
+      )) as { result: number }
+      expect(result.result).toBeCloseTo(expected, 10)
+    })
+
+    it('rejects non-arithmetic input', () => {
+      const def = createDefaultRegistry().get('mathEval')!
+      expect(() => def.execute({ expression: 'alert(1)' }, {})).toThrow(
+        /unsupported characters/,
+      )
+    })
+
+    it('rejects division by zero', () => {
+      const def = createDefaultRegistry().get('mathEval')!
+      expect(() => def.execute({ expression: '1/0' }, {})).toThrow(
+        /division by zero/,
+      )
+    })
+
+    it('rejects malformed parentheses', () => {
+      const def = createDefaultRegistry().get('mathEval')!
+      expect(() => def.execute({ expression: '(1+2' }, {})).toThrow(
+        /parenthesis/,
+      )
+    })
+  })
+
+  describe('kvStoreLookup — credential leak regression', () => {
+    // Mirrors the regression-test pattern in
+    // src/lib/llm-runtime/kv-store.test.ts: any path that could expose
+    // a credential MUST be tested explicitly.
+
+    it('refuses the canonical API key storage key', async () => {
+      const def = createDefaultRegistry().get('kvStoreLookup')!
+      await expect(
+        def.execute({ key: LLM_API_KEY_STORAGE_KEY }, {}),
+      ).rejects.toThrow(/refusing to expose sensitive key/)
+    })
+
+    it('refuses any key matching the sensitive pattern set', async () => {
+      const def = createDefaultRegistry().get('kvStoreLookup')!
+      for (const key of [
+        'openai_api_key',
+        'github_token',
+        'user_password',
+        'session-secret',
+      ]) {
+        await expect(def.execute({ key }, {})).rejects.toThrow(
+          /sensitive key/,
+        )
+      }
+    })
+
+    it('reads a non-sensitive key normally', async () => {
+      const def = createDefaultRegistry().get('kvStoreLookup')!
+      const { kvStore } = await import('@/lib/llm-runtime/kv-store')
+      await kvStore.set('demo:greeting', 'hello')
+      const out = (await def.execute({ key: 'demo:greeting' }, {})) as {
+        key: string
+        value: unknown
+      }
+      expect(out).toEqual({ key: 'demo:greeting', value: 'hello' })
+    })
+  })
+})
+
+describe('hasConfiguredCredential', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns false when secureStorage has no value', async () => {
+    vi.spyOn(secureStorage, 'get').mockResolvedValue(undefined)
+    expect(await hasConfiguredCredential()).toBe(false)
+  })
+
+  it('returns false when secureStorage rejects', async () => {
+    vi.spyOn(secureStorage, 'get').mockRejectedValue(new Error('boom'))
+    expect(await hasConfiguredCredential()).toBe(false)
+  })
+
+  it('returns true for a non-empty string', async () => {
+    vi.spyOn(secureStorage, 'get').mockResolvedValue('sk-test')
+    expect(await hasConfiguredCredential()).toBe(true)
+  })
+
+  it('returns false for an empty string', async () => {
+    vi.spyOn(secureStorage, 'get').mockResolvedValue('')
+    expect(await hasConfiguredCredential()).toBe(false)
+  })
+})
+
+describe('ToolRegistry.buildToolSet — gating', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('hides network/credential-gated tools when no credential is configured', async () => {
+    vi.spyOn(secureStorage, 'get').mockResolvedValue(undefined)
+    const reg = createDefaultRegistry()
+    reg.register({
+      name: 'webSearch',
+      description: 'Hosted web search.',
+      inputSchema: z.object({ q: z.string() }).strict(),
+      requiresNetwork: true,
+      requiresCredential: true,
+      execute: () => ({ results: [] }),
+    })
+    const set = await reg.buildToolSet()
+    expect(Object.keys(set).sort()).toEqual([
+      'currentTime',
+      'kvStoreLookup',
+      'mathEval',
+    ])
+    expect(set).not.toHaveProperty('webSearch')
+  })
+
+  it('exposes gated tools when a credential is configured', async () => {
+    vi.spyOn(secureStorage, 'get').mockResolvedValue('sk-test')
+    const reg = createDefaultRegistry()
+    reg.register({
+      name: 'webSearch',
+      description: 'Hosted web search.',
+      inputSchema: z.object({ q: z.string() }).strict(),
+      requiresNetwork: true,
+      execute: () => ({ results: [] }),
+    })
+    const set = await reg.buildToolSet()
+    expect(set).toHaveProperty('webSearch')
+  })
+
+  it('forceUnlockGatedTools bypasses the credential check (tests only)', async () => {
+    vi.spyOn(secureStorage, 'get').mockResolvedValue(undefined)
+    const reg = createDefaultRegistry()
+    reg.register({
+      name: 'imageGen',
+      description: 'Hosted image generation.',
+      inputSchema: z.object({ prompt: z.string() }).strict(),
+      requiresNetwork: true,
+      execute: () => ({ url: 'data:image/png;base64,deadbeef' }),
+    })
+    const set = await reg.buildToolSet({ forceUnlockGatedTools: true })
+    expect(set).toHaveProperty('imageGen')
+  })
+})

--- a/src/lib/agent/tool-registry.ts
+++ b/src/lib/agent/tool-registry.ts
@@ -1,0 +1,360 @@
+/**
+ * Local-first agent tool registry.
+ *
+ * This is the typed, multi-arg successor to the single-string-arg shim
+ * in `./tool-loop-agent.ts`'s `buildAgentTools()`. Both surfaces coexist;
+ * legacy callers keep working while new code can register tools with
+ * arbitrary Zod input schemas and explicit network / credential gating.
+ *
+ * Design goals
+ *   1. **Local-first by default.** A tool only sees the network if it
+ *      sets `requiresNetwork: true` AND the runtime confirms a hosted
+ *      LLM credential is configured. Otherwise the registry refuses to
+ *      hand it out. This is consistent with the rest of the app's
+ *      "hosted providers stay opt-in" rule.
+ *   2. **No credential leaks.** Tools that look up KV keys reject the
+ *      sensitive prefixes the rest of the codebase pins (mirrors the
+ *      regression test in `src/lib/llm-runtime/kv-store.test.ts`).
+ *   3. **Idempotent registration.** Re-registering the same name throws
+ *      so a typo can't shadow an established tool.
+ *   4. **Backwards compatible.** Adding this file does not change any
+ *      existing tool execution path. The legacy `AgentToolExecutor`
+ *      continues to drive `App.tsx`.
+ */
+
+import { z } from 'zod'
+import { tool } from '@/lib/llm-runtime/ai-sdk'
+import { secureStorage } from '@/lib/native/secure-storage'
+
+/**
+ * Storage key under which the LLM API key is held by `secureStorage`.
+ * Mirrors the constant used throughout `src/lib/llm-runtime/`.
+ */
+export const LLM_API_KEY_STORAGE_KEY = '__llm_runtime_api_key__'
+
+/**
+ * KV key prefixes that must NEVER be exposed to a tool, even one that
+ * legitimately reads from `kvStore`. Mirrors the leak-regression
+ * coverage in `src/lib/llm-runtime/kv-store.test.ts`.
+ */
+const SENSITIVE_KEY_PATTERNS: readonly RegExp[] = [
+  /^__llm_runtime_api_key__/,
+  /api[_-]?key/i,
+  /secret/i,
+  /token/i,
+  /password/i,
+]
+
+export function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEY_PATTERNS.some((re) => re.test(key))
+}
+
+export interface ToolDefinition<
+  TInput extends z.ZodTypeAny = z.ZodTypeAny,
+  TOutput = unknown,
+> {
+  /** Stable machine-readable identifier; used as the tool name. */
+  name: string
+  /** Short description surfaced to the LLM. */
+  description: string
+  /** Zod schema for the tool's input arguments. */
+  inputSchema: TInput
+  /**
+   * If true, the tool may make outbound network calls. Such tools are
+   * only handed out when a hosted-LLM credential is configured (or an
+   * explicit override is supplied at build time).
+   */
+  requiresNetwork?: boolean
+  /**
+   * If true, the tool requires a configured credential (currently
+   * checked against `secureStorage[LLM_API_KEY_STORAGE_KEY]`). Implies
+   * `requiresNetwork`.
+   */
+  requiresCredential?: boolean
+  /** Tool implementation. */
+  execute: (
+    input: z.infer<TInput>,
+    ctx: ToolExecutionContext,
+  ) => Promise<TOutput> | TOutput
+}
+
+export interface ToolExecutionContext {
+  /** AbortSignal threaded through the agent loop, if any. */
+  signal?: AbortSignal
+}
+
+export interface RegistryBuildOptions {
+  /**
+   * If true, network/credential-gated tools are forced into the output
+   * regardless of credential state. Intended for tests only.
+   */
+  forceUnlockGatedTools?: boolean
+}
+
+/**
+ * Read-only view of the registry, suitable for passing around app code
+ * without exposing the mutating `register`.
+ */
+export interface ToolRegistryView {
+  list(): ToolDefinition[]
+  get(name: string): ToolDefinition | undefined
+  has(name: string): boolean
+}
+
+export class ToolRegistry implements ToolRegistryView {
+  private readonly tools = new Map<string, ToolDefinition>()
+
+  /** Register a tool. Throws on duplicate name. */
+  register<TInput extends z.ZodTypeAny, TOutput>(
+    def: ToolDefinition<TInput, TOutput>,
+  ): void {
+    if (this.tools.has(def.name)) {
+      throw new Error(
+        `ToolRegistry: a tool named "${def.name}" is already registered`,
+      )
+    }
+    // Coerce the per-tool generic into the registry's invariant view; the
+    // execute() boundary preserves the original schema's type at the call
+    // site via `inferToolInput`.
+    this.tools.set(def.name, def as unknown as ToolDefinition)
+  }
+
+  /** Replace any existing definition; primarily for tests. */
+  upsert<TInput extends z.ZodTypeAny, TOutput>(
+    def: ToolDefinition<TInput, TOutput>,
+  ): void {
+    this.tools.set(def.name, def as unknown as ToolDefinition)
+  }
+
+  unregister(name: string): boolean {
+    return this.tools.delete(name)
+  }
+
+  list(): ToolDefinition[] {
+    return Array.from(this.tools.values())
+  }
+
+  get(name: string): ToolDefinition | undefined {
+    return this.tools.get(name)
+  }
+
+  has(name: string): boolean {
+    return this.tools.has(name)
+  }
+
+  clear(): void {
+    this.tools.clear()
+  }
+
+  /**
+   * Build a Vercel-AI-SDK tool map ready for `ToolLoopAgent({ tools })`
+   * or `generateText({ tools })`. Network/credential-gated tools are
+   * filtered out unless the runtime confirms a credential — preserving
+   * the local-first guarantee.
+   */
+  async buildToolSet(
+    opts: RegistryBuildOptions = {},
+  ): Promise<Record<string, ReturnType<typeof tool>>> {
+    const credentialPresent = opts.forceUnlockGatedTools
+      ? true
+      : await hasConfiguredCredential()
+
+    const out: Record<string, ReturnType<typeof tool>> = {}
+    for (const def of this.tools.values()) {
+      const gated = def.requiresNetwork || def.requiresCredential
+      if (gated && !credentialPresent) {
+        continue
+      }
+      out[def.name] = wrapAsAiSdkTool(def)
+    }
+    return out
+  }
+}
+
+/**
+ * Returns true if a hosted-LLM credential is currently configured. The
+ * registry uses this to decide whether to expose `requiresNetwork` /
+ * `requiresCredential` tools. Errors from `secureStorage` are
+ * conservatively treated as "no credential" so tools fail closed.
+ */
+export async function hasConfiguredCredential(): Promise<boolean> {
+  try {
+    const v = await secureStorage.get(LLM_API_KEY_STORAGE_KEY)
+    return typeof v === 'string' && v.length > 0
+  } catch {
+    return false
+  }
+}
+
+function wrapAsAiSdkTool(def: ToolDefinition): ReturnType<typeof tool> {
+  return tool({
+    description: def.description,
+    inputSchema: def.inputSchema,
+    execute: async (input: unknown, ctx?: { abortSignal?: AbortSignal }) => {
+      const result = await def.execute(input as z.infer<typeof def.inputSchema>, {
+        signal: ctx?.abortSignal,
+      })
+      return result
+    },
+  }) as unknown as ReturnType<typeof tool>
+}
+
+// ─── Built-in seed tools ────────────────────────────────────────────────
+// All three are zero-network and exercise the registry end-to-end.
+
+const currentTimeTool: ToolDefinition = {
+  name: 'currentTime',
+  description:
+    'Return the current date and time in ISO-8601 form, plus the resolved IANA time zone.',
+  inputSchema: z.object({}).strict(),
+  execute: () => {
+    const now = new Date()
+    return {
+      iso: now.toISOString(),
+      timestamp: now.getTime(),
+      timeZone:
+        Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
+    }
+  },
+}
+
+const mathEvalTool: ToolDefinition = {
+  name: 'mathEval',
+  description:
+    'Evaluate a basic arithmetic expression with +, -, *, /, parentheses, and decimals. Local, no eval(), no network.',
+  inputSchema: z
+    .object({
+      expression: z
+        .string()
+        .min(1)
+        .max(256)
+        .describe('Arithmetic expression, e.g. "(2 + 3) * 4".'),
+    })
+    .strict(),
+  execute: ({ expression }) => {
+    const result = safeArith(expression)
+    return { expression, result }
+  },
+}
+
+const kvStoreLookupTool: ToolDefinition = {
+  name: 'kvStoreLookup',
+  description:
+    'Read a non-sensitive value from the on-device key-value store. Refuses any key that looks credential-shaped.',
+  inputSchema: z
+    .object({
+      key: z
+        .string()
+        .min(1)
+        .max(128)
+        .describe('Non-sensitive KV key. Credential-shaped keys are refused.'),
+    })
+    .strict(),
+  execute: async ({ key }) => {
+    if (isSensitiveKey(key)) {
+      throw new Error(
+        `kvStoreLookup: refusing to expose sensitive key "${key}"`,
+      )
+    }
+    const { kvStore } = await import('@/lib/llm-runtime/kv-store')
+    const value = await kvStore.get(key)
+    return { key, value: value ?? null }
+  },
+}
+
+/** Built-in tools the registry exposes by default. All zero-network. */
+export const BUILTIN_TOOLS: readonly ToolDefinition[] = [
+  currentTimeTool,
+  mathEvalTool,
+  kvStoreLookupTool,
+] as const
+
+/**
+ * Build a fresh registry pre-populated with the local-first built-ins.
+ * Callers can `register(...)` additional tools on top.
+ */
+export function createDefaultRegistry(): ToolRegistry {
+  const reg = new ToolRegistry()
+  for (const def of BUILTIN_TOOLS) {
+    reg.register(def)
+  }
+  return reg
+}
+
+// ─── Internals ─────────────────────────────────────────────────────────
+
+/**
+ * Strict arithmetic evaluator: tokens are limited to digits, operators,
+ * and parentheses; recursion implements standard precedence. No eval(),
+ * no Function constructor, no string concatenation. Throws on malformed
+ * input rather than returning NaN so callers see a clear failure.
+ */
+function safeArith(expr: string): number {
+  const cleaned = expr.replace(/\s+/g, '')
+  if (!/^[0-9+\-*/().]+$/.test(cleaned)) {
+    throw new Error('mathEval: expression contains unsupported characters')
+  }
+
+  let i = 0
+
+  function parseExpression(): number {
+    let value = parseTerm()
+    while (i < cleaned.length && (cleaned[i] === '+' || cleaned[i] === '-')) {
+      const op = cleaned[i++]
+      const rhs = parseTerm()
+      value = op === '+' ? value + rhs : value - rhs
+    }
+    return value
+  }
+
+  function parseTerm(): number {
+    let value = parseFactor()
+    while (i < cleaned.length && (cleaned[i] === '*' || cleaned[i] === '/')) {
+      const op = cleaned[i++]
+      const rhs = parseFactor()
+      if (op === '/') {
+        if (rhs === 0) throw new Error('mathEval: division by zero')
+        value = value / rhs
+      } else {
+        value = value * rhs
+      }
+    }
+    return value
+  }
+
+  function parseFactor(): number {
+    if (cleaned[i] === '+') {
+      i++
+      return parseFactor()
+    }
+    if (cleaned[i] === '-') {
+      i++
+      return -parseFactor()
+    }
+    if (cleaned[i] === '(') {
+      i++
+      const value = parseExpression()
+      if (cleaned[i] !== ')') throw new Error('mathEval: missing closing parenthesis')
+      i++
+      return value
+    }
+    return parseNumber()
+  }
+
+  function parseNumber(): number {
+    const start = i
+    while (i < cleaned.length && /[0-9.]/.test(cleaned[i] as string)) i++
+    if (start === i) throw new Error('mathEval: expected a number')
+    const slice = cleaned.slice(start, i)
+    const n = Number(slice)
+    if (!Number.isFinite(n)) throw new Error(`mathEval: invalid number "${slice}"`)
+    return n
+  }
+
+  const value = parseExpression()
+  if (i !== cleaned.length) {
+    throw new Error(`mathEval: unexpected trailing input at position ${i}`)
+  }
+  if (!Number.isFinite(value)) throw new Error('mathEval: non-finite result')
+  return value
+}


### PR DESCRIPTION
## Summary

Adds `src/lib/agent/tool-registry.ts` — a typed, multi-arg successor to the single-string-arg shim in `tool-loop-agent.ts`. Tools are registered with explicit `requiresNetwork` / `requiresCredential` flags; gated tools are filtered out of the AI-SDK tool map unless `secureStorage` confirms a hosted-LLM credential is configured.

This is item **B** in the agents-and-copilot upgrade slate, and doubles as **Phase 5** of `trueai_upgrade_plan.md`. Unblocks D (critic), E (MCP server), H (agent trace), V (tool docs autogen), W (MCP client).

## What lands

### `src/lib/agent/tool-registry.ts` (new, 360 lines)
- `ToolRegistry` class: typed register / upsert / unregister / list / get / has / clear, plus async `buildToolSet()` that drops gated tools when no credential is present.
- `hasConfiguredCredential()`: reads `secureStorage[__llm_runtime_api_key__]`; treats errors as 'no credential' (fail-closed).
- `isSensitiveKey()`: matches `__llm_runtime_api_key__`, `api_key`, `secret`, `token`, `password` patterns. Used by `kvStoreLookup` and exported for callers wiring their own KV-touching tools.
- Three zero-network seed tools in `BUILTIN_TOOLS`:
  - `currentTime` — ISO timestamp + resolved IANA zone.
  - `mathEval` — hand-rolled recursive-descent arithmetic parser. **No `eval()`, no Function constructor.** Supports +, -, *, /, parentheses, decimals, unary +/-.
  - `kvStoreLookup` — reads `kvStore` but REFUSES any key matching the sensitive-key pattern set.
- `createDefaultRegistry()`: fresh registry pre-loaded with the three built-ins.

### `src/lib/agent/tool-registry.test.ts` (new, 38 cases)
- Registration: register / upsert / unregister / duplicate-rejection.
- Built-ins: each is zero-network; `currentTime`/`mathEval` happy paths.
- `mathEval`: rejects non-arithmetic input, division by zero, malformed parentheses.
- **Leak-regression** (mirrors `src/lib/llm-runtime/kv-store.test.ts`): `kvStoreLookup` refuses `__llm_runtime_api_key__`, `openai_api_key`, `github_token`, `user_password`, `session-secret`. Reads non-sensitive keys normally.
- Gating: hides `webSearch`/`imageGen`-style tools when `secureStorage` has no credential; exposes them when one is configured; `forceUnlockGatedTools` bypasses for tests.
- `hasConfiguredCredential`: false on `undefined`, false on rejection, false on empty string, true on non-empty string.

## What does NOT change

- The legacy `AgentToolExecutor` (`src/lib/agent-tools.ts`) is untouched.
- The existing `buildAgentTools()` shim in `tool-loop-agent.ts` is untouched.
- `App.tsx` and other call sites continue to use the legacy executor. New code can opt in.
- Zero `.github/**` edits, zero new dependencies, zero `package.json` changes.

## Constraints satisfied

- [x] `npm run lint` — `grep tool-registry` on lint output is empty (zero new lint issues from this PR; baseline is 51 errors / 126 warnings on `main`).
- [x] `npm run build:dev` — `tsc --noEmit` passes clean (no errors in `tool-registry.{ts,test.ts}`).
- [x] `npx vitest run src/lib/agent/ src/lib/llm-runtime/ai-sdk/` — 108/108 pass (38 new + 70 pre-existing).
- [x] CodeQL — no new sinks; `mathEval` deliberately avoids `eval` and Function-constructor.
- [x] `package.json` overrides untouched.
- [x] No telemetry, analytics, or third-party network calls added.
- [x] Credential storage rules preserved: `secureStorage` is the only credential-reading path; `kvStore.set`/`kvStore.setSecure` are NOT modified.
- [x] `LICENSE`, `NOTICE`, copyright headers preserved.
- [x] No edits under `.github/**`.

## Lessons learned

- The Vercel-AI-SDK `tool()` helper preserves per-tool generic input/output types, but a heterogeneous registry has to collapse them. Storing as `ToolDefinition` (invariant) and recovering type at the call site via `z.infer` keeps the public surface honest without an unsafe-any escape.
- A hand-rolled recursive-descent arithmetic parser is ~70 lines and avoids `eval` entirely. The legacy `calculator` tool's `Function`-constructor path is one of the items called out in the upgrade plan §Q (sandbox hardening); this PR does not regress that surface.
- jsdom 26 has a known broken `Storage` shim that surfaces as `--localstorage-file was provided without a valid path`. Pre-existing on `main` and addressed by a separate WIP `src/test/setup.ts` polyfill on another branch — explicitly OUT of scope here so this PR stays minimal.

