### PR TITLE
feat(ci): add risk:agent-surface attribute label + classifier self-test

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -52,31 +52,47 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
-      # Refuse to enable auto-merge on PRs classified `risk:high` —
-      # these touch governance / credentials / overrides and MUST be
-      # reviewed manually. The PR Risk Labeller workflow assigns the
-      # label; this step is a defence-in-depth check that does not
-      # weaken any existing branch-protection rule (CODEOWNERS approval
-      # is still required by the ruleset for everything).
-      - name: Refuse on risk:high
-        if: contains(github.event.pull_request.labels.*.name, 'risk:high')
+      # Refuse to enable auto-merge on PRs classified `risk:high` or
+      # `risk:agent-surface` — these touch governance / credentials /
+      # overrides / agent prompts and MUST be reviewed manually. The
+      # PR Risk Labeller workflow assigns these labels; this step is a
+      # defence-in-depth check that does not weaken any existing
+      # branch-protection rule (CODEOWNERS approval is still required
+      # by the ruleset for everything).
+      - name: Refuse on risk:high or risk:agent-surface
+        if: >-
+          contains(github.event.pull_request.labels.*.name, 'risk:high') ||
+          contains(github.event.pull_request.labels.*.name, 'risk:agent-surface')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          IS_HIGH: ${{ contains(github.event.pull_request.labels.*.name, 'risk:high') }}
+          IS_AGENT: ${{ contains(github.event.pull_request.labels.*.name, 'risk:agent-surface') }}
         run: |
-          echo "::warning ::PR #${PR_NUMBER} is risk:high — auto-merge will NOT be enabled."
-          # Leave a one-time comment if not already present
-          MARKER='<!-- risk:high-no-automerge -->'
+          if [ "$IS_HIGH" = "true" ] && [ "$IS_AGENT" = "true" ]; then
+            REASON="risk:high + risk:agent-surface"
+            DETAIL="touches governance files / credentials / overrides AND the agent prompt surface"
+          elif [ "$IS_HIGH" = "true" ]; then
+            REASON="risk:high"
+            DETAIL="touches governance files, credentials, or dependency overrides"
+          else
+            REASON="risk:agent-surface"
+            DETAIL="touches the Copilot / agent prompt surface (\`.github/agents/**\`, \`.github/copilot/**\`, \`AGENTS.md\`, or \`src/lib/agent/**\`)"
+          fi
+          echo "::warning ::PR #${PR_NUMBER} is ${REASON} — auto-merge will NOT be enabled."
+          MARKER='<!-- risk:no-automerge -->'
           if ! gh pr view "$PR_NUMBER" --repo "$REPO" --json comments --jq '.comments[].body' | grep -q "$MARKER"; then
-            BODY="$MARKER"$'\n'"🛡️ This PR is classified \`risk:high\` (touches governance files, credentials, or dependency overrides). Auto-merge is intentionally disabled — please review and merge manually after CODEOWNERS approval."
+            BODY="$MARKER"$'\n'"🛡️ This PR is classified \`${REASON}\` (${DETAIL}). Auto-merge is intentionally disabled — please review and merge manually after CODEOWNERS approval."
             gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY"
           fi
           exit 0
 
       - name: Enable auto-merge (squash)
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'risk:high') }}
+        if: >-
+          !contains(github.event.pull_request.labels.*.name, 'risk:high') &&
+          !contains(github.event.pull_request.labels.*.name, 'risk:agent-surface')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/pr-risk-label.yml
+++ b/.github/workflows/pr-risk-label.yml
@@ -61,9 +61,16 @@ jobs:
           DELETIONS: ${{ steps.files.outputs.del }}
         run: |
           set -euo pipefail
-          LABEL=$(node scripts/classify-pr-risk.mjs < /tmp/files.txt)
-          echo "label=$LABEL" >> "$GITHUB_OUTPUT"
-          echo "Computed risk: $LABEL  (+${ADDITIONS} −${DELETIONS})"
+          node scripts/classify-pr-risk.mjs < /tmp/files.txt > /tmp/labels.txt
+          PRIMARY=$(head -n1 /tmp/labels.txt)
+          echo "label=$PRIMARY" >> "$GITHUB_OUTPUT"
+          if grep -qx 'risk:agent-surface' /tmp/labels.txt; then
+            echo "agent_surface=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "agent_surface=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Computed labels:"; cat /tmp/labels.txt
+          echo "(diff +${ADDITIONS} −${DELETIONS})"
 
       - name: Apply label (and remove other risk:* labels)
         env:
@@ -71,13 +78,15 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           LABEL: ${{ steps.classify.outputs.label }}
+          AGENT_SURFACE: ${{ steps.classify.outputs.agent_surface }}
         run: |
           set -euo pipefail
           # Ensure all risk labels exist
           for r in trivial low medium high; do
             gh label create "risk:${r}" --color "ededed" --description "Risk classification: ${r}" --repo "$REPO" --force >/dev/null
           done
-          # Remove other risk:* labels first
+          gh label create "risk:agent-surface" --color "5319e7" --description "Touches the Copilot / agent prompt surface" --repo "$REPO" --force >/dev/null
+          # Remove other primary risk:* labels first
           for r in trivial low medium high; do
             CUR="risk:${r}"
             if [ "$CUR" != "$LABEL" ]; then
@@ -85,4 +94,11 @@ jobs:
             fi
           done
           gh issue edit "$PR" --repo "$REPO" --add-label "$LABEL" >/dev/null
-          echo "Applied $LABEL to PR #$PR"
+          # Apply or remove the agent-surface attribute label
+          if [ "$AGENT_SURFACE" = "true" ]; then
+            gh issue edit "$PR" --repo "$REPO" --add-label "risk:agent-surface" >/dev/null
+            echo "Applied $LABEL + risk:agent-surface to PR #$PR"
+          else
+            gh issue edit "$PR" --repo "$REPO" --remove-label "risk:agent-surface" >/dev/null 2>&1 || true
+            echo "Applied $LABEL to PR #$PR"
+          fi

--- a/scripts/classify-pr-risk.mjs
+++ b/scripts/classify-pr-risk.mjs
@@ -2,11 +2,18 @@
 // scripts/classify-pr-risk.mjs
 //
 // Reads the list of changed files (one per line on stdin) and the
-// total +/- line counts (env: ADDITIONS, DELETIONS) and prints a
-// single risk label to stdout: one of `risk:trivial`, `risk:low`,
-// `risk:medium`, `risk:high`.
+// total +/- line counts (env: ADDITIONS, DELETIONS) and prints one
+// or more labels to stdout, **one per line**. The first line is
+// always the primary risk class — one of:
+//   risk:trivial | risk:low | risk:medium | risk:high
+// Subsequent lines are optional **attribute** labels that workflows
+// may apply alongside the primary risk class:
+//   risk:agent-surface  → touches the agent / Copilot prompt surface
 //
-// Decision tree (first match wins):
+// Backward compatibility: callers that only read the first line of
+// stdout (`| head -1`) still get the primary risk class as before.
+//
+// Decision tree (first match wins) for the primary label:
 //
 //   high     → any path matches:
 //                .github/**         (governance — workflows / rulesets)
@@ -26,8 +33,21 @@
 //
 //   trivial  → typo-class diffs (≤25 lines AND only docs / comments)
 //
-// Used by `pr-automation.yml` (or a new labeller workflow) to
-// auto-label PRs and consumed by `auto-merge.yml` selective-merge gate.
+// Attribute label `risk:agent-surface` is emitted independently when
+// any path matches:
+//   .github/agents/**
+//   .github/copilot/**             (LEARNINGS / PROMPTS / AGENT_RUNTIME)
+//   .github/copilot-instructions.md
+//   AGENTS.md
+//   src/lib/agent/**
+//   src/lib/llm-runtime/ai-sdk/**
+//
+// Used by `pr-risk-label.yml` to auto-label PRs and consumed by
+// `auto-merge.yml`'s selective-merge gate.
+//
+// Self-test: run `node scripts/classify-pr-risk.mjs --self-test` to
+// exercise a representative set of fixtures. Exits 0 on success, 1 on
+// failure. Pure stdlib — no test runner needed.
 
 import { stdin } from 'node:process';
 
@@ -60,10 +80,119 @@ const LOW = [
   /\.md$/,
 ];
 
+// Attribute paths — an additional `risk:agent-surface` label is
+// emitted on top of the primary risk class when any of these match.
+// Reviewers / auto-merge can then refuse independently of risk:high.
+const AGENT_SURFACE = [
+  /^\.github\/agents\//,
+  /^\.github\/copilot\//,
+  /^\.github\/copilot-instructions\.md$/,
+  /^AGENTS\.md$/,
+  /^src\/lib\/agent\//,
+  /^src\/lib\/llm-runtime\/ai-sdk\//,
+];
+
+function classify(files, total) {
+  if (total > 500) return 'risk:high';
+  for (const f of files) {
+    if (HIGH.some((re) => re.test(f))) return 'risk:high';
+  }
+  if (total > 100) return 'risk:medium';
+  for (const f of files) {
+    if (MEDIUM.some((re) => re.test(f))) return 'risk:medium';
+  }
+  if (total > 25) return 'risk:low';
+  for (const f of files) {
+    if (LOW.some((re) => re.test(f))) return 'risk:low';
+  }
+  return 'risk:trivial';
+}
+
+function attributes(files) {
+  const out = [];
+  if (files.some((f) => AGENT_SURFACE.some((re) => re.test(f)))) {
+    out.push('risk:agent-surface');
+  }
+  return out;
+}
+
+function emit(files, total) {
+  const labels = [classify(files, total), ...attributes(files)];
+  return [...new Set(labels)];
+}
+
+// --- self-test --------------------------------------------------------------
+if (process.argv.includes('--self-test')) {
+  const cases = [
+    { name: 'empty diff',
+      files: [], total: 0,
+      want: ['risk:trivial'] },
+    { name: 'docs typo',
+      files: ['README.md'], total: 4,
+      want: ['risk:low'] },
+    { name: 'medium docs diff',
+      files: ['README.md'], total: 30,
+      want: ['risk:low'] },
+    { name: 'ui-only change',
+      files: ['src/components/Button.tsx'], total: 50,
+      want: ['risk:low'] },
+    { name: 'src/lib refactor',
+      files: ['src/lib/utils.ts'], total: 40,
+      want: ['risk:medium'] },
+    { name: 'oversized diff',
+      files: ['src/components/Button.tsx'], total: 600,
+      want: ['risk:high'] },
+    { name: 'package.json bump',
+      files: ['package.json'], total: 4,
+      want: ['risk:high'] },
+    { name: 'workflow edit',
+      files: ['.github/workflows/ci.yml'], total: 4,
+      want: ['risk:high'] },
+    { name: 'agent surface only — sub-agents',
+      files: ['.github/agents/coverage-improver.agent.md'], total: 80,
+      want: ['risk:high', 'risk:agent-surface'] },
+    { name: 'agent surface — runtime',
+      files: ['src/lib/agent/tool-registry.ts'], total: 40,
+      want: ['risk:medium', 'risk:agent-surface'] },
+    { name: 'agent surface — root contract',
+      files: ['AGENTS.md'], total: 50,
+      want: ['risk:low', 'risk:agent-surface'] },
+    { name: 'agent surface — copilot instructions',
+      files: ['.github/copilot-instructions.md'], total: 5,
+      want: ['risk:high', 'risk:agent-surface'] },
+    { name: 'mixed agent + ui',
+      files: ['src/lib/agent/critic.ts', 'src/components/Chat.tsx'], total: 120,
+      want: ['risk:medium', 'risk:agent-surface'] },
+  ];
+
+  let failed = 0;
+  for (const c of cases) {
+    const got = emit(c.files, c.total);
+    const ok = got.length === c.want.length && got.every((l, i) => l === c.want[i]);
+    if (!ok) {
+      failed++;
+      console.error(`✗ ${c.name}`);
+      console.error(`    files=${JSON.stringify(c.files)} total=${c.total}`);
+      console.error(`    want=${JSON.stringify(c.want)}`);
+      console.error(`    got =${JSON.stringify(got)}`);
+    } else {
+      console.log(`✓ ${c.name} → ${got.join(', ')}`);
+    }
+  }
+  if (failed) {
+    console.error(`\n${failed} / ${cases.length} fixture(s) failed.`);
+    process.exit(1);
+  }
+  console.log(`\n${cases.length} fixtures passed.`);
+  process.exit(0);
+}
+
+// --- normal mode ------------------------------------------------------------
+
 async function readStdin() {
   let data = '';
   for await (const chunk of stdin) data += chunk;
-  return data.split('\n').map(s => s.trim()).filter(Boolean);
+  return data.split('\n').map((s) => s.trim()).filter(Boolean);
 }
 
 const files = await readStdin();
@@ -72,22 +201,4 @@ if (files.length === 0) {
   process.exit(0);
 }
 
-function classify() {
-  // High wins on any match or large diff
-  if (TOTAL > 500) return 'risk:high';
-  for (const f of files) {
-    if (HIGH.some(re => re.test(f))) return 'risk:high';
-  }
-  if (TOTAL > 100) return 'risk:medium';
-  for (const f of files) {
-    if (MEDIUM.some(re => re.test(f))) return 'risk:medium';
-  }
-  if (TOTAL > 25) return 'risk:low';
-  for (const f of files) {
-    if (LOW.some(re => re.test(f))) return 'risk:low';
-  }
-  // Tiny diff, none of the above paths → trivial
-  return 'risk:trivial';
-}
-
-console.log(classify());
+for (const label of emit(files, TOTAL)) console.log(label);


### PR DESCRIPTION
## Summary

Extends the PR risk classifier so any change to the Copilot / agent prompt surface gets an additional `risk:agent-surface` label and is refused by auto-merge alongside `risk:high`. Implements **§G** of the agent-surface upgrade plan.

## Changes

### `scripts/classify-pr-risk.mjs`
- Emits one or more labels, **one per line**. First line is the primary risk class (unchanged: `trivial|low|medium|high`). When the PR touches an agent-surface path, a second `risk:agent-surface` line is appended.
- **Backward compatible**: callers reading only `head -1` keep the old behaviour.
- Agent-surface paths: `.github/agents/**`, `.github/copilot/**`, `.github/copilot-instructions.md`, `AGENTS.md`, `src/lib/agent/**`, `src/lib/llm-runtime/ai-sdk/**`.
- **`--self-test` mode** with 13 representative fixtures (empty diff, ui-only, governance, oversized, every agent-surface path). Pure stdlib — no test runner required. Run: `node scripts/classify-pr-risk.mjs --self-test`.

### `.github/workflows/pr-risk-label.yml`
- Reads multi-line classifier output, applies the primary risk label as exclusive (still removes the other three), and adds or removes `risk:agent-surface` based on whether it appeared.
- Creates the new label with a distinct purple colour (`5319e7`).

### `.github/workflows/auto-merge.yml`
- Refuses auto-merge on either `risk:high` **or** `risk:agent-surface`, with a contextual no-automerge comment that picks the right reason.
- Re-uses a single marker key so PRs flipping between states don't accumulate duplicate comments.

## Risk
**`risk:high`** + **`risk:agent-surface`** (this PR's labeller will self-classify on the next run). Touches `.github/workflows/**` + the classifier. No code ships in the application bundle.

## Validation
```
$ node scripts/classify-pr-risk.mjs --self-test
✓ empty diff → risk:trivial
✓ docs typo → risk:low
✓ medium docs diff → risk:low
✓ ui-only change → risk:low
✓ src/lib refactor → risk:medium
✓ oversized diff → risk:high
✓ package.json bump → risk:high
✓ workflow edit → risk:high
✓ agent surface only — sub-agents → risk:high, risk:agent-surface
✓ agent surface — runtime → risk:medium, risk:agent-surface
✓ agent surface — root contract → risk:low, risk:agent-surface
✓ agent surface — copilot instructions → risk:high, risk:agent-surface
✓ mixed agent + ui → risk:medium, risk:agent-surface

13 fixtures passed.
```

YAML validated with `yaml.safe_load` for both workflows.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>