### PR TITLE
chore(codeowners): require owner review on agent-surface paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,3 +28,22 @@
 /package.json               @smackypants
 /package-lock.json          @smackypants
 /android/app/build.gradle   @smackypants
+
+# Agent surface — every prompt, instruction file, sub-agent definition, tool
+# registry, and runtime adapter that an LLM-driven agent reads or executes
+# *must* be approved by the project owner. These paths control how Copilot
+# and any external agents behave inside this repository, so unreviewed changes
+# here have outsized blast radius (prompt injection, tool drift, data leaks).
+#
+# Keep this list in sync with the `risk:agent-surface` classifier in
+# scripts/classify-pr-risk.mjs — both should match the same path set.
+/AGENTS.md                                  @smackypants
+/.github/copilot-instructions.md            @smackypants
+/.github/copilot/                           @smackypants
+/.github/agents/                            @smackypants
+/src/lib/agent/                             @smackypants
+/src/lib/llm-runtime/ai-sdk/                @smackypants
+/scripts/classify-pr-risk.mjs               @smackypants
+/scripts/check-prompts-lock.mjs             @smackypants
+/scripts/check-instructions-drift.mjs       @smackypants
+/scripts/check-agents.mjs                   @smackypants


### PR DESCRIPTION
## Summary

Implements **§T** of the agent-surface upgrade plan. Adds CODEOWNERS entries that mirror the `risk:agent-surface` path set used by the PR risk classifier (PR #44), so every change to a prompt, instruction file, sub-agent definition, tool registry, runtime adapter, or any of the agent-related lint scripts is gated on a review from @smackypants — even if a future Actions or GitHub App identity has bypass rights elsewhere.

## Defense layers

1. `classify-pr-risk.mjs` (PR #44) labels these PRs `risk:agent-surface` and `auto-merge.yml` refuses to merge them.
2. **CODEOWNERS forces a human review** regardless of label state, even for direct pushes or PRs from a privileged identity.

## Path set (kept in sync with classify-pr-risk.mjs)

| Path | Why owner review |
| --- | --- |
| `AGENTS.md` | Portable agent contract |
| `.github/copilot-instructions.md` | System prompt for Copilot CLI |
| `.github/copilot/` | All prompts, learnings, lockfile |
| `.github/agents/` | Sub-agent definitions |
| `src/lib/agent/` | Agent runtime |
| `src/lib/llm-runtime/ai-sdk/` | LLM adapter |
| `scripts/{classify-pr-risk,check-prompts-lock,check-instructions-drift,check-agents}.mjs` | Linters that enforce all of the above |

## Forward-compat

CODEOWNERS allows non-existent paths; entries for files currently on open PR branches (#38, #41, #43, #44, #47) start enforcing the moment those PRs land. **No CI behaviour change for paths not yet present.**

## Risk
`risk:high` + `risk:agent-surface` — touches `.github/CODEOWNERS` itself. Self-consistent: this PR will require @smackypants review under the pre-existing `/.github/  @smackypants` rule.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>