### PR TITLE
test(agent): golden eval harness + 3 fixtures for ToolLoopAgent

### DIFF
--- a/src/lib/agent/__evals__/calculator-only.eval.test.ts
+++ b/src/lib/agent/__evals__/calculator-only.eval.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Golden eval: single-tool calculator goal.
+ *
+ * Goal: "what is (2 + 3) * 4"
+ * Expected agent behaviour:
+ *   1. Plan a single calculator call with input "(2 + 3) * 4".
+ *   2. Receive "Result: 20" from the executor.
+ *   3. Summarise with a final text response.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { runEval, expectedSequence } from '@/test/agent-eval-harness'
+
+describe('agent eval: calculator-only', () => {
+  it('dispatches a single calculator call and stops', async () => {
+    const result = await runEval({
+      goal: 'what is (2 + 3) * 4',
+      toolOutputs: {
+        calculator: 'Result: 20',
+      },
+      script: [
+        {
+          kind: 'tool-calls',
+          calls: [{ tool: 'calculator', input: '(2 + 3) * 4' }],
+        },
+        {
+          kind: 'final',
+          text: 'The answer is 20.',
+        },
+      ],
+    })
+
+    expect(result.toolCalls).toEqual(
+      expectedSequence({ tool: 'calculator', input: '(2 + 3) * 4' }),
+    )
+    expect(result.finalText).toMatch(/20/)
+    expect(result.modelCalls).toBe(2)
+  })
+})

--- a/src/lib/agent/__evals__/file-reader-summarizer.eval.test.ts
+++ b/src/lib/agent/__evals__/file-reader-summarizer.eval.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Golden eval: multi-tool plan, dispatched in correct order.
+ *
+ * Goal: "summarise the file ./README.md"
+ * Expected agent behaviour:
+ *   1. Call file_reader to load the file.
+ *   2. Call summarizer with the loaded text.
+ *   3. Final answer paraphrases the summary.
+ *
+ * This pins the *ordering* contract: we want the agent to never
+ * call summarizer before file_reader, because the summarizer's
+ * input depends on the file_reader's output.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { runEval, expectedSequence } from '@/test/agent-eval-harness'
+
+describe('agent eval: file_reader → summarizer chain', () => {
+  it('reads the file before summarising and emits both calls in order', async () => {
+    const fileContents = '# Hello\n\nA repo for local-first agents.'
+    const summary = 'A repo for local-first agents.'
+
+    const result = await runEval({
+      goal: 'summarise the file ./README.md',
+      toolOutputs: {
+        file_reader: fileContents,
+        summarizer: summary,
+      },
+      script: [
+        {
+          kind: 'tool-calls',
+          calls: [{ tool: 'file_reader', input: './README.md' }],
+        },
+        {
+          kind: 'tool-calls',
+          calls: [{ tool: 'summarizer', input: fileContents }],
+        },
+        {
+          kind: 'final',
+          text: `Summary: ${summary}`,
+        },
+      ],
+    })
+
+    expect(result.toolCalls).toEqual(
+      expectedSequence(
+        { tool: 'file_reader', input: './README.md' },
+        { tool: 'summarizer', input: fileContents },
+      ),
+    )
+    expect(result.toolCalls[0].tool).toBe('file_reader')
+    expect(result.toolCalls[1].tool).toBe('summarizer')
+    expect(result.finalText).toContain(summary)
+    expect(result.modelCalls).toBe(3)
+  })
+})

--- a/src/lib/agent/__evals__/web-search-fail-closed.eval.test.ts
+++ b/src/lib/agent/__evals__/web-search-fail-closed.eval.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Golden eval: local-first fail-closed contract.
+ *
+ * Goal: "search the web for X"
+ * Expected agent behaviour in this local-first runtime:
+ *   1. Try `web_search` once.
+ *   2. Receive an explicit failure ("not available in local-first runtime").
+ *   3. Surface the limitation in the final answer rather than
+ *      pretending the call succeeded.
+ *
+ * This pins the most important *correctness* property: when a
+ * tool fails closed, the agent must NOT silently retry until the
+ * loop budget is exhausted, and must NOT confabulate output.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { runEval, expectedSequence } from '@/test/agent-eval-harness'
+
+describe('agent eval: local-first fail-closed', () => {
+  it('does not retry web_search and surfaces the limitation in the final text', async () => {
+    const result = await runEval({
+      goal: 'search the web for the latest TrueAI release',
+      toolOutputs: {
+        web_search: {
+          success: false,
+          output: 'web_search not available in local-first runtime',
+        },
+      },
+      script: [
+        {
+          kind: 'tool-calls',
+          calls: [{ tool: 'web_search', input: 'latest TrueAI release' }],
+        },
+        {
+          kind: 'final',
+          text:
+            'I cannot search the web in this local-first runtime; ' +
+            "the web_search tool failed because no search backend is wired.",
+        },
+      ],
+    })
+
+    expect(result.toolCalls).toEqual(
+      expectedSequence({ tool: 'web_search', input: 'latest TrueAI release' }),
+    )
+    // Critical: only ONE web_search attempt — the agent must not
+    // hammer a fail-closed tool repeatedly.
+    expect(
+      result.toolCalls.filter((c) => c.tool === 'web_search').length,
+    ).toBe(1)
+    expect(result.finalText).toMatch(/local-first|not available|cannot/i)
+  })
+})

--- a/src/test/agent-eval-harness.ts
+++ b/src/test/agent-eval-harness.ts
@@ -1,0 +1,186 @@
+/**
+ * Agent eval harness — golden tests for `ToolLoopAgent` behaviour.
+ *
+ * The harness builds a *scripted* mock language model that walks
+ * through a fixture-defined sequence of responses, then asserts the
+ * agent invoked the executor with the expected (toolName, input)
+ * tuples in order.
+ *
+ * Why this exists
+ *   The agent loop is one of the highest-blast-radius parts of the
+ *   codebase: a regression here silently turns Copilot / on-device
+ *   sessions into noise without producing any visible failure. The
+ *   prior coverage was a single 97-line happy-path test in
+ *   `tool-loop-agent.test.ts`. This harness lets us pin a growing
+ *   library of deterministic goal → tool-sequence fixtures so
+ *   refactors of the loop (planned: §B tool-registry, §D critic,
+ *   §P budget guard) can proceed with confidence.
+ *
+ * Determinism
+ *   No real model is invoked. The scripted model emits exactly the
+ *   tool-call / text content the fixture supplies, in order. The
+ *   executor is a stub that returns canned outputs, so we never run
+ *   real `web_search`, `image_generator`, etc. — meaning these
+ *   evals are safe to run in any CI / device sandbox.
+ */
+
+import { MockLanguageModelV3 } from 'ai/test'
+import type { LanguageModel } from '@/lib/llm-runtime/ai-sdk'
+import { AgentToolExecutor } from '@/lib/agent-tools'
+import { buildTrueAIAgent } from '@/lib/agent/tool-loop-agent'
+import type { AgentTool } from '@/lib/types'
+
+/**
+ * One scripted "turn" the model produces. Either a list of tool
+ * calls (causing the agent to dispatch them in parallel through
+ * the executor) or a final text response (terminating the loop).
+ */
+export type ScriptedTurn =
+  | { kind: 'tool-calls'; calls: { tool: AgentTool; input: string }[] }
+  | { kind: 'final'; text: string }
+
+/**
+ * Map of `AgentTool` → canned output string. Defaults to a generic
+ * stub if a tool isn't listed. The executor records every call for
+ * later assertion.
+ */
+export type StubToolOutputs = Partial<Record<AgentTool, string | { success: boolean; output: string }>>
+
+export interface RunEvalOptions {
+  /** The user goal that gets passed to `agent.generate({ prompt })`. */
+  goal: string
+  /** Scripted model turns, in order. The last one MUST be `kind: 'final'`. */
+  script: ScriptedTurn[]
+  /** Canned tool outputs. Missing tools return a generic stub. */
+  toolOutputs?: StubToolOutputs
+  /** Optional system-prompt override. */
+  system?: string
+}
+
+export interface EvalResult {
+  /** Every `executor.executeTool(...)` call, in order. */
+  toolCalls: { tool: AgentTool; input: string }[]
+  /** The final assistant text the agent produced. */
+  finalText: string
+  /** Number of `doGenerate` invocations the model received. */
+  modelCalls: number
+}
+
+let __callIdSeq = 0
+function nextCallId(): string {
+  __callIdSeq += 1
+  return `call_${__callIdSeq}`
+}
+
+/**
+ * Build a `LanguageModel` that walks `script` linearly. Tool-call
+ * turns emit `tool-call` content parts with `finishReason:
+ * 'tool-calls'`; the final turn emits a single text part with
+ * `finishReason: 'stop'`. Calls past the script length throw —
+ * a fixture that doesn't terminate is a bug in the fixture.
+ */
+function scriptedModel(script: ScriptedTurn[], onCall: () => void): LanguageModel {
+  let cursor = 0
+  return new MockLanguageModelV3({
+    provider: 'eval-harness',
+    modelId: 'scripted',
+    doGenerate: async () => {
+      onCall()
+      if (cursor >= script.length) {
+        throw new Error(
+          `agent-eval-harness: model exhausted at step ${cursor}; ` +
+            `script has ${script.length} turns. Fixture likely missing a final turn.`,
+        )
+      }
+      const turn = script[cursor++]
+
+      if (turn.kind === 'final') {
+        return {
+          content: [{ type: 'text', text: turn.text }],
+          finishReason: 'stop',
+          usage: { inputTokens: 4, outputTokens: 4, totalTokens: 8 },
+          warnings: [],
+        }
+      }
+
+      return {
+        content: turn.calls.map((c) => ({
+          type: 'tool-call' as const,
+          toolCallId: nextCallId(),
+          toolName: c.tool,
+          // The AI SDK parses tool-call input from a JSON-encoded
+          // *string* via safeParseJSON. Passing a raw object skips
+          // execution silently (the parse becomes a no-op and tools
+          // never run). JSON-stringify the args object so the SDK
+          // can validate it against the tool's Zod inputSchema.
+          input: JSON.stringify({ input: c.input }),
+        })),
+        finishReason: 'tool-calls',
+        usage: { inputTokens: 4, outputTokens: 2 * turn.calls.length, totalTokens: 4 + 2 * turn.calls.length },
+        warnings: [],
+      }
+    },
+  } as unknown as ConstructorParameters<typeof MockLanguageModelV3>[0]) as unknown as LanguageModel
+}
+
+/**
+ * Run a fixture and return the recorded tool-call sequence + final
+ * text. Stateless: each call gets its own executor + agent.
+ */
+export async function runEval(opts: RunEvalOptions): Promise<EvalResult> {
+  const recorded: { tool: AgentTool; input: string }[] = []
+  const outputs = opts.toolOutputs ?? {}
+
+  const executor = new AgentToolExecutor()
+  // Replace executeTool with a deterministic stub that records every
+  // call and returns the fixture's canned output. We do not call
+  // through to the real tools — a `calculator` eval should not hit
+  // the real eval(), a `web_search` eval should not hit the network,
+  // etc.
+  ;(executor as unknown as {
+    executeTool: (tool: AgentTool, input: string) => Promise<{ success: boolean; output: string }>
+  }).executeTool = async (tool, input) => {
+    recorded.push({ tool, input })
+    const o = outputs[tool]
+    if (o === undefined) {
+      return { success: true, output: `stub:${tool}(${input})` }
+    }
+    if (typeof o === 'string') {
+      return { success: true, output: o }
+    }
+    return o
+  }
+
+  let modelCalls = 0
+  const model = scriptedModel(opts.script, () => {
+    modelCalls += 1
+  })
+
+  const agent = buildTrueAIAgent({ model, executor, system: opts.system })
+
+  // ToolLoopAgent's generate signature is variant-shaped depending
+  // on AI SDK version; we cast through unknown for the eval harness.
+  const result = (await (
+    agent as unknown as {
+      generate: (req: { prompt: string }) => Promise<{ text: string }>
+    }
+  ).generate({ prompt: opts.goal })) as { text: string }
+
+  return {
+    toolCalls: recorded,
+    finalText: result.text ?? '',
+    modelCalls,
+  }
+}
+
+/**
+ * Convenience matcher: assert recorded tool calls equal the
+ * expected sequence (deep-equal). Call from a test with
+ *   expect(result.toolCalls).toEqual(expectedSequence)
+ * — but importing this keeps the assertion phrasing consistent.
+ */
+export function expectedSequence(
+  ...calls: { tool: AgentTool; input: string }[]
+): { tool: AgentTool; input: string }[] {
+  return calls
+}


### PR DESCRIPTION
## Summary

Implements **§M** of the agent-surface upgrade plan. Adds a deterministic eval harness for the agent loop and three golden fixtures pinning the most important behavioural contracts.

## Why

Previously the only coverage of `buildTrueAIAgent` was a single 97-line happy-path unit test. Several upcoming refactors (§B tool-registry, §D critic loop, §P budget guard) all rewire the loop in subtle ways, and a regression there silently degrades every Copilot / on-device agent session without a CI signal.

## Harness — `src/test/agent-eval-harness.ts`

- `runEval({ goal, script, toolOutputs })` builds a scripted `MockLanguageModelV3`, swaps in a stub executor that records every `executeTool(name, input)` call, runs the agent, and returns the recorded tool sequence + final text.
- Stateless: each call gets its own executor + agent.
- **No real network**: `web_search` / `image_generator` / `api_caller` are all stubbed, safe to run in any sandbox.
- Tool-call `input` is **JSON-stringified** to match how `@ai-sdk/ai`'s `doParseToolCall` consumes it (`safeParseJSON({ text: toolCall.input, schema })` — passing a raw object silently no-ops).

## Fixtures — `src/lib/agent/__evals__/`

| Fixture | Pinned contract |
|---|---|
| `calculator-only.eval.test.ts` | Single tool dispatch + clean termination |
| `file-reader-summarizer.eval.test.ts` | **Ordering**: summarizer must never fire before file_reader |
| `web-search-fail-closed.eval.test.ts` | **Local-first**: fail-closed tool tried *exactly once*, failure surfaced honestly, no confabulation |

## Validation

- ✅ All 3 new evals pass.
- ✅ All 10 `src/lib/agent` tests still pass.
- ✅ No production code changed.

## Risk
`risk:low` + `risk:agent-surface` — tests + helper only. `agent-surface` because the fixtures pin the contract future loop refactors must satisfy.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>