### PR TITLE
feat(agent): local-only opt-in agent trace ring buffer (§H)

### DIFF
--- a/src/lib/agent/trace.test.ts
+++ b/src/lib/agent/trace.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  AGENT_TRACE_KEY,
+  AGENT_TRACE_ENABLED_KEY,
+  MAX_ENTRIES,
+  __resetTraceCacheForTests,
+  clearTrace,
+  exportTraceAsJsonl,
+  isTraceEnabled,
+  readTrace,
+  recordTraceEvent,
+  setTraceEnabled,
+} from './trace'
+import { kvStore } from '@/lib/llm-runtime/kv-store'
+
+beforeEach(async () => {
+  __resetTraceCacheForTests()
+  await kvStore.set(AGENT_TRACE_KEY, [])
+  await kvStore.set(AGENT_TRACE_ENABLED_KEY, false)
+})
+
+afterEach(async () => {
+  __resetTraceCacheForTests()
+})
+
+describe('agent trace', () => {
+  it('is disabled by default and recordTraceEvent is a no-op', async () => {
+    expect(await isTraceEnabled()).toBe(false)
+    await recordTraceEvent('run-1', 'prompt', { text: 'hello' })
+    expect(await readTrace()).toEqual([])
+  })
+
+  it('persists enable/disable preference and surfaces it on next call', async () => {
+    await setTraceEnabled(true)
+    expect(await isTraceEnabled()).toBe(true)
+
+    __resetTraceCacheForTests()
+    expect(await isTraceEnabled()).toBe(true)
+
+    await setTraceEnabled(false)
+    expect(await isTraceEnabled()).toBe(false)
+  })
+
+  it('appends events with monotonically increasing seq numbers', async () => {
+    await setTraceEnabled(true)
+
+    await recordTraceEvent('run-1', 'run-start', { goal: 'demo' })
+    await recordTraceEvent('run-1', 'prompt', { text: 'add 2 and 3' })
+    await recordTraceEvent('run-1', 'tool-call', {
+      name: 'mathEval',
+      input: { expression: '2+3' },
+    })
+    await recordTraceEvent('run-1', 'tool-result', {
+      name: 'mathEval',
+      output: { result: 5 },
+    })
+    await recordTraceEvent('run-1', 'run-end', { ok: true })
+
+    const trace = await readTrace()
+    expect(trace.map((e) => e.seq)).toEqual([1, 2, 3, 4, 5])
+    expect(trace.map((e) => e.kind)).toEqual([
+      'run-start',
+      'prompt',
+      'tool-call',
+      'tool-result',
+      'run-end',
+    ])
+    for (const e of trace) {
+      expect(e.runId).toBe('run-1')
+      expect(typeof e.ts).toBe('string')
+      expect(() => new Date(e.ts).toISOString()).not.toThrow()
+    }
+  })
+
+  it('strips credential-shaped keys before persistence', async () => {
+    await setTraceEnabled(true)
+    await recordTraceEvent('run-1', 'tool-call', {
+      name: 'evil',
+      api_key: 'sk-leak',
+      apiKey: 'sk-leak2',
+      __llm_runtime_api_key__: 'sk-leak3',
+      authToken: 'leak',
+      Password: 'leak',
+      safeField: 'kept',
+    })
+    const [event] = await readTrace()
+    expect(event.data).toEqual({ name: 'evil', safeField: 'kept' })
+    expect(JSON.stringify(event)).not.toContain('sk-leak')
+    expect(JSON.stringify(event)).not.toContain('Password')
+  })
+
+  it('honours the ring-buffer cap', async () => {
+    await setTraceEnabled(true)
+    const overflow = MAX_ENTRIES + 12
+    for (let i = 0; i < overflow; i++) {
+      await recordTraceEvent('run-1', 'prompt', { i })
+    }
+    const trace = await readTrace()
+    expect(trace).toHaveLength(MAX_ENTRIES)
+    // Oldest survivor's seq equals total - MAX_ENTRIES + 1.
+    expect(trace[0].seq).toBe(overflow - MAX_ENTRIES + 1)
+    expect(trace[trace.length - 1].seq).toBe(overflow)
+  })
+
+  it('exports as JSONL with one event per line', async () => {
+    await setTraceEnabled(true)
+    await recordTraceEvent('run-1', 'run-start', { goal: 'x' })
+    await recordTraceEvent('run-1', 'run-end', { ok: true })
+    const jsonl = await exportTraceAsJsonl()
+    const lines = jsonl.split('\n')
+    expect(lines).toHaveLength(2)
+    expect(JSON.parse(lines[0]).kind).toBe('run-start')
+    expect(JSON.parse(lines[1]).kind).toBe('run-end')
+  })
+
+  it('clearTrace empties the buffer', async () => {
+    await setTraceEnabled(true)
+    await recordTraceEvent('run-1', 'prompt', { x: 1 })
+    expect(await readTrace()).toHaveLength(1)
+    await clearTrace()
+    expect(await readTrace()).toEqual([])
+  })
+
+  it('does NOT write to localStorage with a credential-shaped key (regression)', async () => {
+    // Mirrors the regression in src/lib/llm-runtime/kv-store.test.ts:
+    // even though we explicitly scrub credential-shaped fields, also
+    // confirm the public trace key itself is NOT credential-shaped.
+    expect(AGENT_TRACE_KEY.startsWith('__llm_runtime_api_key__')).toBe(false)
+    expect(/api[_-]?key|secret|token|password/i.test(AGENT_TRACE_KEY)).toBe(false)
+  })
+})

--- a/src/lib/agent/trace.ts
+++ b/src/lib/agent/trace.ts
@@ -1,0 +1,140 @@
+/**
+ * §H — Local-only agent telemetry (trace).
+ *
+ * Provides a structured, ring-buffered JSONL trace of agent runs persisted
+ * via the on-device `kvStore`. Visible only to the user (e.g. via Settings
+ * → Agent → Show trace). NEVER transmitted off-device.
+ *
+ * Design points:
+ *   1. **Local-only.** Reads and writes go through `kvStore`, the same
+ *      IndexedDB-backed store as the rest of the app. No network calls.
+ *   2. **Bounded.** A ring buffer with `MAX_ENTRIES` entries keeps the
+ *      cost on every agent run constant. Older entries are evicted FIFO.
+ *   3. **No leakage.** Trace records carry user prompts and tool I/O; we
+ *      strip any field whose key matches the credential-shaped prefixes
+ *      that `tool-registry.ts` already pins, mirroring the leak
+ *      regression in `kv-store.test.ts`.
+ *   4. **Opt-in.** `recordTraceEvent` is a no-op unless `enableTrace()`
+ *      has been called this session (or persisted via `setTraceEnabled`).
+ */
+
+import { kvStore } from '@/lib/llm-runtime/kv-store'
+import { isSensitiveKey } from './tool-registry'
+
+/** kv-store key under which the trace ring buffer lives. */
+export const AGENT_TRACE_KEY = '__agent_trace__'
+/** kv-store key for the user's enable/disable preference. */
+export const AGENT_TRACE_ENABLED_KEY = '__agent_trace_enabled__'
+
+/** Maximum number of events kept in the ring buffer. */
+export const MAX_ENTRIES = 500
+
+export type TraceEventKind =
+  | 'run-start'
+  | 'run-end'
+  | 'prompt'
+  | 'tool-call'
+  | 'tool-result'
+  | 'verdict'
+  | 'error'
+
+export interface TraceEvent {
+  /** Monotonic sequence number assigned at append time. */
+  seq: number
+  /** ISO-8601 timestamp. */
+  ts: string
+  /** Logical run id; lets a session correlate events. */
+  runId: string
+  kind: TraceEventKind
+  /** Free-form structured payload. Sensitive keys are stripped. */
+  data: Record<string, unknown>
+}
+
+let inMemoryEnabled: boolean | null = null
+
+/**
+ * Returns whether tracing is currently enabled. Reads the persisted
+ * preference once per session and caches it in memory; subsequent
+ * `setTraceEnabled` calls update both layers.
+ */
+export async function isTraceEnabled(): Promise<boolean> {
+  if (inMemoryEnabled !== null) return inMemoryEnabled
+  const persisted = await kvStore.get<boolean>(AGENT_TRACE_ENABLED_KEY)
+  inMemoryEnabled = persisted === true
+  return inMemoryEnabled
+}
+
+/** Enable tracing for the current session and persist the preference. */
+export async function setTraceEnabled(enabled: boolean): Promise<void> {
+  inMemoryEnabled = enabled
+  await kvStore.set(AGENT_TRACE_ENABLED_KEY, enabled)
+}
+
+/** Test-only escape hatch to reset the in-memory cache. */
+export function __resetTraceCacheForTests(): void {
+  inMemoryEnabled = null
+}
+
+/**
+ * Append a single event to the ring buffer. No-op when tracing is
+ * disabled. Sensitive top-level fields in `data` are scrubbed before
+ * persistence.
+ */
+export async function recordTraceEvent(
+  runId: string,
+  kind: TraceEventKind,
+  data: Record<string, unknown> = {},
+): Promise<void> {
+  if (!(await isTraceEnabled())) return
+
+  const existing = (await kvStore.get<TraceEvent[]>(AGENT_TRACE_KEY)) ?? []
+  const seq = existing.length === 0 ? 1 : existing[existing.length - 1].seq + 1
+  const event: TraceEvent = {
+    seq,
+    ts: new Date().toISOString(),
+    runId,
+    kind,
+    data: scrubSensitive(data),
+  }
+  const next = existing.concat(event)
+  // Ring-buffer eviction: trim from the front so the most recent
+  // MAX_ENTRIES survive. We slice once rather than a loop so a caller
+  // that imported a huge backlog converges in a single write.
+  const trimmed = next.length > MAX_ENTRIES ? next.slice(next.length - MAX_ENTRIES) : next
+  await kvStore.set(AGENT_TRACE_KEY, trimmed)
+}
+
+/** Read the full trace (oldest → newest). */
+export async function readTrace(): Promise<TraceEvent[]> {
+  const events = (await kvStore.get<TraceEvent[]>(AGENT_TRACE_KEY)) ?? []
+  return events.slice()
+}
+
+/** Erase the entire trace. */
+export async function clearTrace(): Promise<void> {
+  await kvStore.set(AGENT_TRACE_KEY, [])
+}
+
+/**
+ * Render the trace as JSONL — each event on its own line. Useful for
+ * `npm run agent:replay` (§U) and for users exporting their own trace
+ * for support.
+ */
+export async function exportTraceAsJsonl(): Promise<string> {
+  const events = await readTrace()
+  return events.map((e) => JSON.stringify(e)).join('\n')
+}
+
+/**
+ * Return a shallow copy of `data` with any top-level credential-shaped
+ * key removed. Mirrors `tool-registry.isSensitiveKey` — keeping a single
+ * sensitivity policy for the whole agent surface.
+ */
+function scrubSensitive(data: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(data)) {
+    if (isSensitiveKey(k)) continue
+    out[k] = v
+  }
+  return out
+}


### PR DESCRIPTION
## §H — Agent telemetry (local-only)

Implements plan item §H. Adds a structured, opt-in trace of agent runs
that lives entirely on-device and feeds future tooling (§U replay CLI,
§D critic verdict surfacing).

### What

- `src/lib/agent/trace.ts` — `TraceEvent` ring buffer (500 entries) in `kvStore` under `__agent_trace__`. Disabled by default. Sensitive top-level fields are scrubbed via `tool-registry.isSensitiveKey` so the agent surface keeps **one** sensitivity policy.
- `src/lib/agent/trace.test.ts` — 8 tests: opt-in default, persistence, seq monotonicity, scrubbing, ring-buffer cap, JSONL export, clear, key-shape regression.

### Constraints

- Local-first ✅ — only writes to `kvStore`, no network calls.
- Credential leakage guard ✅ — mirrors `kv-store.test.ts` regression.
- Backwards compatible ✅ — no changes to existing files; `recordTraceEvent` is a no-op until `setTraceEnabled(true)`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>