### PR TITLE
feat(agents): per-agent allowed_paths/allowed_labels scoping (§R)

### DIFF
--- a/.github/agents/android-doctor.agent.md
+++ b/.github/agents/android-doctor.agent.md
@@ -1,6 +1,15 @@
 ---
 name: android-doctor
 description: Diagnoses and fixes Capacitor 8 / Android Gradle Plugin / JDK 21 issues in the TrueAI LocalAI Android build. Reads `scripts/android-doctor.sh`, the Gradle build, and the AndroidManifest.xml, and proposes minimal fixes for compileSdk / minSdk / targetSdk drift, plugin compatibility, and lifecycle bugs.
+allowed_paths:
+  - "android/**"
+  - "scripts/android-doctor.sh"
+  - "capacitor.config.ts"
+  - "capacitor.config.json"
+allowed_labels:
+  - "android"
+  - "capacitor"
+  - "risk:high"
 ---
 
 You are **android-doctor**, the native-mobile teammate for **TrueAI LocalAI**.

--- a/.github/agents/coverage-improver.agent.md
+++ b/.github/agents/coverage-improver.agent.md
@@ -1,6 +1,17 @@
 ---
 name: coverage-improver
 description: Targeted Vitest coverage lift for TrueAI LocalAI, focused on the `src/` top-level shells (App.tsx, App-Enhanced.tsx, main.tsx) which are currently the largest absolute uncovered surface in the repo.
+allowed_paths:
+  - "src/**"
+  - "vitest.config.ts"
+  - "vitest.setup.ts"
+  - "scripts/ratchet-coverage-thresholds.mjs"
+  - "scripts/regen-coverage-roadmap.mjs"
+allowed_labels:
+  - "tests"
+  - "coverage"
+  - "risk:low"
+  - "risk:medium"
 ---
 
 You are **coverage-improver**, a Vitest-focused teammate for **TrueAI LocalAI** (React + TypeScript + Vite + Tailwind + shadcn/ui + Capacitor Android).

--- a/.github/agents/dep-bumper.agent.md
+++ b/.github/agents/dep-bumper.agent.md
@@ -1,6 +1,18 @@
 ---
 name: dep-bumper
 description: Triages Dependabot alerts and OSV / Trivy / npm audit findings for TrueAI LocalAI, applying minimal-impact dependency upgrades that respect the project's hard pins and AGP 9.x constraints.
+allowed_paths:
+  - "package.json"
+  - "package-lock.json"
+  - ".github/dependabot.yml"
+  - "android/gradle/**"
+  - "android/build.gradle"
+  - "android/app/build.gradle"
+allowed_labels:
+  - "dependencies"
+  - "security"
+  - "risk:medium"
+  - "risk:high"
 ---
 
 You are **dep-bumper**, a dependency-hygiene teammate for **TrueAI LocalAI**.

--- a/.github/agents/docs-curator.agent.md
+++ b/.github/agents/docs-curator.agent.md
@@ -1,6 +1,14 @@
 ---
 name: docs-curator
 description: Keeps the TrueAI LocalAI documentation tree in shape — consolidates the 60+ root-level `*_COMPLETE.md` / `*_GUIDE.md` files into a structured `docs/` tree, archives stale phase reports, and updates the README + AGENTS.md cross-references after each consolidation.
+allowed_paths:
+  - "docs/**"
+  - "*.md"
+  - "AGENTS.md"
+  - "README.md"
+allowed_labels:
+  - "docs"
+  - "risk:low"
 ---
 
 You are **docs-curator**, the documentation-hygiene teammate for **TrueAI LocalAI**.

--- a/.github/agents/release-shepherd.agent.md
+++ b/.github/agents/release-shepherd.agent.md
@@ -1,6 +1,17 @@
 ---
 name: release-shepherd
 description: Drives the TrueAI LocalAI release process — runs the pre-flight checklist for `release-bump.yml` / `tag-release.yml`, writes the CHANGELOG entry, and never touches LICENSE / NOTICE / rulesets.
+allowed_paths:
+  - "CHANGELOG.md"
+  - "package.json"
+  - "package-lock.json"
+  - "android/app/build.gradle"
+  - "src/version.ts"
+  - "docs/RELEASES.md"
+allowed_labels:
+  - "release"
+  - "risk:medium"
+  - "risk:high"
 ---
 
 You are **release-shepherd**, the release-engineering teammate for **TrueAI LocalAI**.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",
         "check:agents": "node scripts/check-agent-frontmatter.mjs",
+        "check:agent-permissions": "node scripts/check-agent-permissions.mjs",
         "check:prompts": "node scripts/check-prompts-lock.mjs",
         "check:instructions": "node scripts/check-instructions-drift.mjs",
         "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/scripts/check-agent-frontmatter.mjs
+++ b/scripts/check-agent-frontmatter.mjs
@@ -113,6 +113,37 @@ for (const file of files) {
     seenNames.set(name, rel)
   }
 
+  // §R — optional permission-scoping fields. Parsed only for shape;
+  // enforcement against PR diffs lives in scripts/check-agent-permissions.mjs.
+  const allowedPaths = parseYamlList(block, 'allowed_paths')
+  const allowedLabels = parseYamlList(block, 'allowed_labels')
+  if (allowedPaths !== null) {
+    if (allowedPaths.length === 0) {
+      violations.push(
+        `${rel}: \`allowed_paths\` is declared but empty; either remove the key or list at least one glob`,
+      )
+    }
+    for (const p of allowedPaths) {
+      if (typeof p !== 'string' || p.trim() === '') {
+        violations.push(`${rel}: \`allowed_paths\` entries must be non-empty strings`)
+        break
+      }
+    }
+  }
+  if (allowedLabels !== null) {
+    if (allowedLabels.length === 0) {
+      violations.push(
+        `${rel}: \`allowed_labels\` is declared but empty; either remove the key or list at least one label`,
+      )
+    }
+    for (const l of allowedLabels) {
+      if (typeof l !== 'string' || l.trim() === '') {
+        violations.push(`${rel}: \`allowed_labels\` entries must be non-empty strings`)
+        break
+      }
+    }
+  }
+
   // Filename consistency: prefer <name>.agent.md. Allow the legacy
   // my-agent.agent.md (declared name: bug-fix-teammate) until that
   // file is renamed in a separate PR.
@@ -140,3 +171,57 @@ const out = summary.join('\n')
 console.error(out)
 console.log(out)
 process.exit(1)
+
+/**
+ * Minimal YAML block-list parser sufficient for `allowed_paths:` and
+ * `allowed_labels:` style fields. Handles:
+ *
+ *   key:
+ *     - "value-one"
+ *     - 'value-two'
+ *     - bare-value
+ *
+ * Returns null if `key:` is absent (so callers can distinguish "not
+ * declared" from "declared empty"). Values are returned as strings with
+ * surrounding quotes stripped. Indentation is permissive: any
+ * positive-indent dash line that follows the key (until a non-list line)
+ * is collected.
+ */
+function parseYamlList(block, key) {
+  const lines = block.split(/\r?\n/)
+  const keyRe = new RegExp(`^${key}\\s*:\\s*(.*)$`)
+  const out = []
+  let inList = false
+
+  for (const raw of lines) {
+    if (!inList) {
+      const m = keyRe.exec(raw)
+      if (m) {
+        const inline = m[1].trim()
+        if (inline.length > 0 && inline !== '|' && inline !== '>') {
+          // Inline flow form `key: [a, b]` — best-effort parse.
+          if (inline.startsWith('[') && inline.endsWith(']')) {
+            const inner = inline.slice(1, -1).trim()
+            if (inner === '') return []
+            return inner
+              .split(',')
+              .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+          }
+          return null // unsupported scalar form; treat as not-a-list
+        }
+        inList = true
+      }
+      continue
+    }
+    // In-list mode: collect `  - value` rows; stop at the first
+    // non-indented, non-dash line.
+    if (/^\s*-\s+/.test(raw)) {
+      const v = raw.replace(/^\s*-\s+/, '').trim().replace(/^["']|["']$/g, '')
+      out.push(v)
+      continue
+    }
+    if (/^\s*$/.test(raw)) continue
+    if (/^\S/.test(raw)) break
+  }
+  return inList ? out : null
+}

--- a/scripts/check-agent-permissions.mjs
+++ b/scripts/check-agent-permissions.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+// scripts/check-agent-permissions.mjs
+//
+// §R — Per-agent path / label authorisation gate.
+//
+// Validates that the files changed by a PR routed to a given agent fall
+// inside that agent's `allowed_paths` glob list (declared in the agent's
+// front-matter). Optionally also validates a list of labels against
+// `allowed_labels`. Refuses to run an agent that has no `allowed_paths`
+// declared — the lack of declaration is the failure mode (fail closed).
+//
+// Usage
+//   node scripts/check-agent-permissions.mjs --agent <name> [--paths-from -|<file>] [--labels lbl,lbl,...]
+//
+//   --agent <name>          Required. Slug from a .github/agents/*.agent.md
+//                           front-matter `name:` field.
+//   --paths-from -          Read changed paths from stdin (one per line).
+//   --paths-from <file>     Read changed paths from a file, one per line.
+//   --paths a,b,c           Inline comma-separated list (alt to --paths-from).
+//   --labels lbl1,lbl2      Inline comma-separated list of PR labels.
+//
+// CI usage
+//   git diff --name-only origin/main...HEAD | \
+//     node scripts/check-agent-permissions.mjs --agent android-doctor --paths-from -
+//
+// Exit codes
+//   0  every changed path is authorised (and any labels are authorised)
+//   1  one or more violations
+//   2  could not run (agent not found, no allowed_paths, etc.)
+//
+// Pure Node stdlib — no third-party deps.
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const REPO_ROOT = resolve(__dirname, '..')
+const AGENTS_DIR = resolve(REPO_ROOT, '.github/agents')
+
+function parseArgv(argv) {
+  const args = { agent: null, pathsFrom: null, paths: null, labels: null }
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--agent') args.agent = argv[++i]
+    else if (a === '--paths-from') args.pathsFrom = argv[++i]
+    else if (a === '--paths') args.paths = argv[++i]
+    else if (a === '--labels') args.labels = argv[++i]
+    else if (a === '--help' || a === '-h') {
+      printUsage()
+      process.exit(0)
+    } else {
+      console.error(`Unknown argument: ${a}`)
+      printUsage()
+      process.exit(2)
+    }
+  }
+  return args
+}
+
+function printUsage() {
+  console.error(
+    'usage: check-agent-permissions --agent <name> [--paths-from -|<file>|--paths a,b,c] [--labels l1,l2]',
+  )
+}
+
+async function readPaths(args) {
+  if (args.paths) {
+    return args.paths
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+  }
+  if (args.pathsFrom === '-') {
+    const raw = await readStdin()
+    return raw.split(/\r?\n/).map((s) => s.trim()).filter(Boolean)
+  }
+  if (args.pathsFrom) {
+    return readFileSync(args.pathsFrom, 'utf8')
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+  }
+  return []
+}
+
+function readStdin() {
+  return new Promise((res) => {
+    let data = ''
+    process.stdin.setEncoding('utf8')
+    process.stdin.on('data', (chunk) => (data += chunk))
+    process.stdin.on('end', () => res(data))
+    if (process.stdin.isTTY) res('')
+  })
+}
+
+function loadAgents() {
+  if (!existsSync(AGENTS_DIR)) {
+    console.error(`✗ Cannot find ${AGENTS_DIR}`)
+    process.exit(2)
+  }
+  const files = readdirSync(AGENTS_DIR)
+    .filter((f) => f.endsWith('.agent.md'))
+    .map((f) => resolve(AGENTS_DIR, f))
+  const agents = []
+  for (const file of files) {
+    const body = readFileSync(file, 'utf8')
+    if (!body.startsWith('---\n') && !body.startsWith('---\r\n')) continue
+    const after = body.slice(4)
+    const closeIdx = after.search(/\n---\s*\n/)
+    if (closeIdx < 0) continue
+    const block = after.slice(0, closeIdx)
+    const name = (block.match(/^name:\s*(.+?)\s*$/m) || [])[1]
+    if (!name) continue
+    agents.push({
+      name: name.trim(),
+      file: file.slice(REPO_ROOT.length + 1),
+      allowedPaths: parseYamlList(block, 'allowed_paths'),
+      allowedLabels: parseYamlList(block, 'allowed_labels'),
+    })
+  }
+  return agents
+}
+
+/**
+ * Convert a glob ("src/**", "android/app/build.gradle", "*.md") to an
+ * anchored RegExp. Supports `**` (any segments incl. zero), `*` (any
+ * chars excluding `/`), and `?` (single char). Other regex metacharacters
+ * are escaped. POSIX paths only — callers normalise backslashes upstream.
+ */
+export function globToRegExp(glob) {
+  let re = '^'
+  let i = 0
+  while (i < glob.length) {
+    const c = glob[i]
+    if (c === '*' && glob[i + 1] === '*') {
+      // `**/` — zero or more segments. `**` alone — match anything.
+      if (glob[i + 2] === '/') {
+        re += '(?:.*/)?'
+        i += 3
+      } else {
+        re += '.*'
+        i += 2
+      }
+    } else if (c === '*') {
+      re += '[^/]*'
+      i++
+    } else if (c === '?') {
+      re += '[^/]'
+      i++
+    } else if (/[.+^${}()|[\]\\]/.test(c)) {
+      re += '\\' + c
+      i++
+    } else {
+      re += c
+      i++
+    }
+  }
+  re += '$'
+  return new RegExp(re)
+}
+
+function pathMatches(path, globs) {
+  return globs.some((g) => globToRegExp(g).test(path))
+}
+
+async function main() {
+  const args = parseArgv(process.argv)
+  if (!args.agent) {
+    printUsage()
+    process.exit(2)
+  }
+  const agents = loadAgents()
+  const agent = agents.find((a) => a.name === args.agent)
+  if (!agent) {
+    console.error(`✗ No agent named "${args.agent}" found in ${AGENTS_DIR}`)
+    console.error(`  Known: ${agents.map((a) => a.name).sort().join(', ')}`)
+    process.exit(2)
+  }
+
+  const paths = await readPaths(args)
+  const labels = args.labels
+    ? args.labels.split(',').map((s) => s.trim()).filter(Boolean)
+    : []
+
+  const violations = []
+
+  if (!agent.allowedPaths || agent.allowedPaths.length === 0) {
+    violations.push(
+      `agent "${agent.name}" (${agent.file}) declares no \`allowed_paths\` — refusing to authorise any change. Add an \`allowed_paths\` list to its front-matter.`,
+    )
+  } else if (paths.length === 0) {
+    console.log(`✓ agent "${agent.name}": no changed paths supplied — nothing to check.`)
+  } else {
+    for (const p of paths) {
+      if (!pathMatches(p, agent.allowedPaths)) {
+        violations.push(
+          `agent "${agent.name}" is not authorised to modify "${p}" (not in allowed_paths)`,
+        )
+      }
+    }
+  }
+
+  if (labels.length > 0 && agent.allowedLabels && agent.allowedLabels.length > 0) {
+    for (const l of labels) {
+      if (!agent.allowedLabels.includes(l)) {
+        violations.push(
+          `agent "${agent.name}" is not authorised to add label "${l}" (not in allowed_labels)`,
+        )
+      }
+    }
+  }
+
+  if (violations.length === 0) {
+    if (paths.length > 0) {
+      console.log(
+        `✓ agent "${agent.name}": ${paths.length} path(s) and ${labels.length} label(s) authorised.`,
+      )
+    }
+    process.exit(0)
+  }
+
+  console.error('✗ Agent permission violations:')
+  for (const v of violations) console.error(`  - ${v}`)
+  process.exit(1)
+}
+
+/**
+ * Minimal YAML block-list parser; mirrors the helper in
+ * scripts/check-agent-frontmatter.mjs. Returns null when the key is
+ * absent so the caller can distinguish "undeclared" from "empty".
+ */
+function parseYamlList(block, key) {
+  const lines = block.split(/\r?\n/)
+  const keyRe = new RegExp(`^${key}\\s*:\\s*(.*)$`)
+  const out = []
+  let inList = false
+  for (const raw of lines) {
+    if (!inList) {
+      const m = keyRe.exec(raw)
+      if (m) {
+        const inline = m[1].trim()
+        if (inline.length > 0 && inline !== '|' && inline !== '>') {
+          if (inline.startsWith('[') && inline.endsWith(']')) {
+            const inner = inline.slice(1, -1).trim()
+            if (inner === '') return []
+            return inner
+              .split(',')
+              .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+          }
+          return null
+        }
+        inList = true
+      }
+      continue
+    }
+    if (/^\s*-\s+/.test(raw)) {
+      out.push(raw.replace(/^\s*-\s+/, '').trim().replace(/^["']|["']$/g, ''))
+      continue
+    }
+    if (/^\s*$/.test(raw)) continue
+    if (/^\S/.test(raw)) break
+  }
+  return inList ? out : null
+}
+
+const isMain =
+  process.argv[1] && resolve(process.argv[1]) === __filename
+if (isMain) {
+  main().catch((err) => {
+    console.error(err.stack || err.message || String(err))
+    process.exit(2)
+  })
+}


### PR DESCRIPTION
## §R — Per-agent permission scoping

Implements plan item §R: each `.github/agents/*.agent.md` declares the **minimum** set of repo paths and PR labels it may modify. A new `check-agent-permissions.mjs` enforces the contract against a PR's actual diff.

### What

- **Linter extension** (`scripts/check-agent-frontmatter.mjs`): now validates optional YAML `allowed_paths` and `allowed_labels` block-lists for shape.
- **Enforcement** (`scripts/check-agent-permissions.mjs`):
  ```
  git diff --name-only origin/main...HEAD | \
    node scripts/check-agent-permissions.mjs --agent android-doctor --paths-from -
  ```
  Falls closed — an agent with no `allowed_paths` declared cannot authorise any change.
- **Agent declarations**: scoped front-matter for android-doctor, coverage-improver, dep-bumper, docs-curator, release-shepherd. `bug-fix-teammate` (legacy) is intentionally left unscoped; the gate refuses it until `allowed_paths` is added.
- **npm script**: `check:agent-permissions` for ad-hoc / CI use.

### Why

Pairs with `risk:agent-surface` (§G) and CODEOWNERS (§T): the dispatcher (or a future PR check) can refuse a PR from agent X that touched paths outside its mandate, even if the human reviewer rubber-stamps the diff.

### Risk

Pure-script + agent-md additions. No production code paths touched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>