### PR TITLE
feat(agent): structured-verdict critic loop (§D)

### DIFF
--- a/src/lib/agent/critic.test.ts
+++ b/src/lib/agent/critic.test.ts
@@ -1,0 +1,131 @@
+/**
+ * §D — Critic agent loop tests.
+ *
+ * Validates that:
+ *   1. The critic runs `generateObject` with the verdict schema and
+ *      surfaces the model's structured output verbatim.
+ *   2. A failing model resolves with a fail-closed verdict (no throw).
+ *   3. The critic flags a known regression: executor that returned
+ *      "I cannot search the web" when the goal required search and a
+ *      webSearch tool was available → ok=false, missing populated.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { MockLanguageModelV3 } from 'ai/test'
+import type { LanguageModel } from '@/lib/llm-runtime/ai-sdk'
+import { critiqueAgentRun, VerdictSchema, type Verdict } from './critic'
+
+/**
+ * Build a model that, when asked for a JSON object, returns the
+ * provided verdict serialised. The Vercel AI SDK's `generateObject`
+ * sends a constrained-JSON request that resolves to the verdict shape
+ * after running through the schema validator.
+ */
+function modelReturningVerdict(verdict: Verdict): LanguageModel {
+  return new MockLanguageModelV3({
+    provider: 'mock-critic',
+    modelId: 'mock-critic-model',
+    doGenerate: async () => {
+      return {
+        content: [{ type: 'text', text: JSON.stringify(verdict) }],
+        finishReason: 'stop',
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        warnings: [],
+      }
+    },
+  } as unknown as ConstructorParameters<typeof MockLanguageModelV3>[0]) as unknown as LanguageModel
+}
+
+function modelThatThrows(message: string): LanguageModel {
+  return new MockLanguageModelV3({
+    provider: 'mock-critic',
+    modelId: 'mock-critic-error',
+    doGenerate: async () => {
+      throw new Error(message)
+    },
+  } as unknown as ConstructorParameters<typeof MockLanguageModelV3>[0]) as unknown as LanguageModel
+}
+
+describe('critic', () => {
+  it('surfaces a positive verdict from a well-formed model response', async () => {
+    const expected: Verdict = {
+      ok: true,
+      missing: [],
+      unsafe: [],
+      rationale: 'executor produced the requested sum.',
+    }
+    const verdict = await critiqueAgentRun(
+      { goal: 'add 2 and 3', output: 'The answer is 5.' },
+      { model: modelReturningVerdict(expected) },
+    )
+    expect(verdict).toEqual(expected)
+    expect(VerdictSchema.parse(verdict)).toEqual(expected)
+  })
+
+  it('flags a known regression: refused doable web-search task', async () => {
+    const expected: Verdict = {
+      ok: false,
+      missing: ['web search backend'],
+      unsafe: [],
+      rationale:
+        "executor declined despite a webSearch tool being available.",
+    }
+    const verdict = await critiqueAgentRun(
+      {
+        goal: 'find me the latest changelog for vite',
+        output: 'I cannot search the web.',
+        availableTools: ['webSearch', 'currentTime'],
+      },
+      { model: modelReturningVerdict(expected) },
+    )
+    expect(verdict.ok).toBe(false)
+    expect(verdict.missing).toContain('web search backend')
+  })
+
+  it('returns a fail-closed verdict when the model errors out', async () => {
+    const verdict = await critiqueAgentRun(
+      { goal: 'anything', output: 'whatever' },
+      { model: modelThatThrows('network down') },
+    )
+    expect(verdict.ok).toBe(false)
+    expect(verdict.rationale).toContain('critic unavailable')
+    expect(verdict.rationale).toContain('network down')
+    expect(verdict.missing).toEqual([])
+    expect(verdict.unsafe).toEqual([])
+  })
+
+  it('forwards an abort signal to the underlying generateObject call', async () => {
+    const onCall = vi.fn()
+    const model = new MockLanguageModelV3({
+      provider: 'mock-critic',
+      modelId: 'mock-critic-abort',
+      doGenerate: async (callOpts: unknown) => {
+        onCall(callOpts)
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                ok: true,
+                missing: [],
+                unsafe: [],
+                rationale: 'fine.',
+              }),
+            },
+          ],
+          finishReason: 'stop',
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          warnings: [],
+        }
+      },
+    } as unknown as ConstructorParameters<typeof MockLanguageModelV3>[0]) as unknown as LanguageModel
+    const ctrl = new AbortController()
+    await critiqueAgentRun(
+      { goal: 'g', output: 'o' },
+      { model, abortSignal: ctrl.signal },
+    )
+    expect(onCall).toHaveBeenCalledTimes(1)
+    const callOpts = onCall.mock.calls[0][0] as { abortSignal?: AbortSignal }
+    expect(callOpts.abortSignal).toBe(ctrl.signal)
+  })
+})

--- a/src/lib/agent/critic.ts
+++ b/src/lib/agent/critic.ts
@@ -1,0 +1,139 @@
+/**
+ * §D — Critic agent loop.
+ *
+ * Runs a single LLM pass with a structured Zod verdict over the original
+ * goal + the executor's final output. Surfaces whether the executor
+ * answered the goal, what it missed, and any unsafe behaviour observed.
+ *
+ * Local-first: the critic uses the same `LanguageModel` as the executor
+ * by default — no second provider configured, no extra hosted credential
+ * required.
+ *
+ * Non-blocking by design: the critic verdict is returned alongside the
+ * executor result, never replacing it. UI surfaces decide how to render
+ * it (a small "verification" line in the chat).
+ */
+
+import { z } from 'zod'
+import { generateObject, type LanguageModel } from '@/lib/llm-runtime/ai-sdk'
+
+/**
+ * Structured verdict produced by the critic. Shape is intentionally
+ * narrow so the SDK's `generateObject` produces something stable across
+ * model families.
+ */
+export const VerdictSchema = z
+  .object({
+    ok: z
+      .boolean()
+      .describe(
+        'true if the executor output addresses the goal correctly; false otherwise.',
+      ),
+    missing: z
+      .array(z.string())
+      .describe(
+        'List of concrete capabilities or facts the executor failed to provide. Empty when ok=true.',
+      ),
+    unsafe: z
+      .array(z.string())
+      .describe(
+        'List of unsafe or policy-violating behaviours observed in the executor output. Empty when none.',
+      ),
+    rationale: z
+      .string()
+      .describe('One-sentence justification for the verdict.'),
+  })
+  .strict()
+
+export type Verdict = z.infer<typeof VerdictSchema>
+
+const DEFAULT_SYSTEM_PROMPT = [
+  'You are a strict but fair *critic* evaluating whether another agent',
+  'addressed the user goal. Reply ONLY by populating the structured',
+  'verdict object — do not add prose outside the schema.',
+  '',
+  'Return ok=false when the executor declined a doable task, returned',
+  'an off-topic answer, hallucinated a capability it does not have, or',
+  "left a critical part of the goal unanswered. Populate `missing` with",
+  'specific shortfalls. Populate `unsafe` only for behaviours that would',
+  'leak credentials, exfiltrate data, or violate the project policy.',
+].join('\n')
+
+export interface CritiqueInput {
+  /** The user goal as originally posed to the executor. */
+  goal: string
+  /** The executor's final user-visible answer. */
+  output: string
+  /**
+   * Optional list of tool names the executor invoked. Lets the critic
+   * notice e.g. "executor said 'I cannot search the web' but the
+   * runtime had a webSearch tool".
+   */
+  availableTools?: readonly string[]
+  /** Override the default system prompt. */
+  systemPrompt?: string
+}
+
+export interface CritiqueOptions {
+  /** LLM to use; reuse the executor's by default for local-first. */
+  model: LanguageModel
+  /**
+   * Forwarded to `generateObject({ abortSignal })`. Lets the chat UI
+   * cancel a slow critic without blocking the executor's result.
+   */
+  abortSignal?: AbortSignal
+  /**
+   * Cap critic temperature low (0.1) for stable judgements; callers can
+   * override if they want more variety.
+   */
+  temperature?: number
+}
+
+/**
+ * Run the critic pass. Always resolves with a `Verdict`; on any error
+ * (network, schema mismatch, abort) returns a fail-closed verdict with
+ * `ok=false` and a rationale describing the failure. The critic is
+ * advisory, so a critic outage MUST NOT block surfacing the executor's
+ * answer.
+ */
+export async function critiqueAgentRun(
+  input: CritiqueInput,
+  opts: CritiqueOptions,
+): Promise<Verdict> {
+  const userPrompt = renderUserPrompt(input)
+  try {
+    const { object } = await generateObject({
+      model: opts.model,
+      schema: VerdictSchema,
+      system: input.systemPrompt ?? DEFAULT_SYSTEM_PROMPT,
+      prompt: userPrompt,
+      abortSignal: opts.abortSignal,
+      temperature: opts.temperature ?? 0.1,
+    })
+    return object
+  } catch (err) {
+    return {
+      ok: false,
+      missing: [],
+      unsafe: [],
+      rationale: `critic unavailable: ${err instanceof Error ? err.message : String(err)}`,
+    }
+  }
+}
+
+function renderUserPrompt(input: CritiqueInput): string {
+  const lines = [
+    '## Goal',
+    input.goal.trim(),
+    '',
+    '## Executor output',
+    input.output.trim(),
+  ]
+  if (input.availableTools && input.availableTools.length > 0) {
+    lines.push('', '## Tools the executor had access to')
+    for (const t of input.availableTools) {
+      lines.push(`- ${t}`)
+    }
+  }
+  return lines.join('\n')
+}


### PR DESCRIPTION
## §D — Critic agent loop

Implements plan item §D. Adds a non-blocking verification pass that scores executor output against the original goal.

### What

- `src/lib/agent/critic.ts` — `critiqueAgentRun({goal, output, availableTools?}, {model, abortSignal?})` ⇒ `{ ok, missing[], unsafe[], rationale }` via `generateObject` + Zod `VerdictSchema`.
- Fail-closed: any error resolves with `ok=false` + a clear rationale rather than throwing — the critic is advisory.
- Local-first: no second provider; reuses the executor's `LanguageModel`.

### Tests

4 cases covering: positive verdict, refusal-of-doable-task regression, model error fail-close, abort signal forwarding.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>