### PR TITLE
fix(ci): add issues:write to auto-lint-fix.yml permissions

### DIFF
--- a/.github/workflows/auto-lint-fix.yml
+++ b/.github/workflows/auto-lint-fix.yml
@@ -18,6 +18,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   lint-fix:


### PR DESCRIPTION
Follow-up to #46. The dispatcher step calls `gh issue create` but the workflow only declares `contents: write` + `pull-requests: write`, so the API returns 'Resource not accessible by integration (createIssue)' before any assignee-tolerance code path runs. `pr-quality.yml` already has this permission — bringing `auto-lint-fix.yml` into line.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>