### PR TITLE
feat(hooks): useAgent React hook (§O)

### DIFF
--- a/src/hooks/use-agent.test.ts
+++ b/src/hooks/use-agent.test.ts
@@ -1,0 +1,169 @@
+/**
+ * §O — `useAgent` hook tests.
+ *
+ * Pins the public hook contract: status transitions (idle → running →
+ * done / aborted / error), text accumulation, tool-event tracking, and
+ * the abort path. Uses the same MockLanguageModelV3 + simulateReadableStream
+ * pattern as src/lib/agent/streaming.test.ts.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { MockLanguageModelV3, simulateReadableStream } from 'ai/test'
+import type { LanguageModel } from '@/lib/llm-runtime/ai-sdk'
+import { useAgent } from './use-agent'
+import {
+  AGENT_TRACE_KEY,
+  AGENT_TRACE_ENABLED_KEY,
+  __resetTraceCacheForTests,
+  readTrace,
+  setTraceEnabled,
+} from '@/lib/agent/trace'
+import { kvStore } from '@/lib/llm-runtime/kv-store'
+
+beforeEach(async () => {
+  __resetTraceCacheForTests()
+  await kvStore.set(AGENT_TRACE_KEY, [])
+  await kvStore.set(AGENT_TRACE_ENABLED_KEY, false)
+})
+
+afterEach(() => {
+  __resetTraceCacheForTests()
+})
+
+function streamingMock(chunks: string[]): LanguageModel {
+  return new MockLanguageModelV3({
+    provider: 'mock',
+    modelId: 'mock',
+    doGenerate: async () => ({
+      content: [{ type: 'text', text: chunks.join('') }],
+      finishReason: 'stop',
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      warnings: [],
+    }),
+    doStream: async () => ({
+      stream: simulateReadableStream({
+        chunks: [
+          { type: 'stream-start' as const, warnings: [] },
+          {
+            type: 'response-metadata' as const,
+            id: 'r1',
+            timestamp: new Date(),
+            modelId: 'mock',
+          },
+          { type: 'text-start' as const, id: 't1' },
+          ...chunks.map((c) => ({
+            type: 'text-delta' as const,
+            id: 't1',
+            delta: c,
+          })),
+          { type: 'text-end' as const, id: 't1' },
+          {
+            type: 'finish' as const,
+            finishReason: 'stop' as const,
+            usage: { inputTokens: 1, outputTokens: chunks.length, totalTokens: 1 + chunks.length },
+          },
+        ],
+      }),
+    }),
+  } as unknown as ConstructorParameters<typeof MockLanguageModelV3>[0]) as unknown as LanguageModel
+}
+
+describe('useAgent', () => {
+  it('transitions idle → running → done and accumulates text', async () => {
+    const model = streamingMock(['Hi', ', ', 'there'])
+    const { result } = renderHook(() => useAgent({ model, tools: [] }))
+    expect(result.current.status).toBe('idle')
+    expect(result.current.text).toBe('')
+
+    await act(async () => {
+      await result.current.run('say hi')
+    })
+
+    expect(result.current.status).toBe('done')
+    expect(result.current.text).toBe('Hi, there')
+    expect(result.current.error).toBeNull()
+  })
+
+  it('exposes a fresh AbortController per run that abort() can cancel', async () => {
+    // Build a model whose stream never closes until aborted, by using
+    // a manually-controlled ReadableStream.
+    const model = new MockLanguageModelV3({
+      provider: 'mock',
+      modelId: 'mock-stuck',
+      doGenerate: async () => ({
+        content: [{ type: 'text', text: 'never' }],
+        finishReason: 'stop',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        warnings: [],
+      }),
+      doStream: async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        return {
+          stream: new ReadableStream({
+            async start(controller) {
+              controller.enqueue({ type: 'stream-start', warnings: [] })
+              controller.enqueue({
+                type: 'response-metadata',
+                id: 'r',
+                timestamp: new Date(),
+                modelId: 'mock-stuck',
+              })
+              controller.enqueue({ type: 'text-start', id: 't' })
+              controller.enqueue({ type: 'text-delta', id: 't', delta: 'partial' })
+              if (abortSignal) {
+                await new Promise<void>((res) => {
+                  abortSignal.addEventListener('abort', () => res(), { once: true })
+                })
+              }
+              controller.close()
+            },
+          }),
+        }
+      },
+    } as unknown as ConstructorParameters<typeof MockLanguageModelV3>[0]) as unknown as LanguageModel
+
+    const { result } = renderHook(() => useAgent({ model, tools: [] }))
+    let runPromise: Promise<void>
+    await act(async () => {
+      runPromise = result.current.run('blocked goal')
+      // Yield so the run gets a chance to start.
+      await new Promise((r) => setTimeout(r, 10))
+    })
+    expect(result.current.status).toBe('running')
+
+    await act(async () => {
+      result.current.abort()
+      await runPromise!
+    })
+    expect(result.current.status).toBe('aborted')
+  })
+
+  it('records trace events when tracing is enabled', async () => {
+    await setTraceEnabled(true)
+    const model = streamingMock(['ok'])
+    const { result } = renderHook(() =>
+      useAgent({ model, tools: [], runId: 'fixed-run-1' }),
+    )
+    await act(async () => {
+      await result.current.run('hello')
+    })
+    await waitFor(async () => {
+      const trace = await readTrace()
+      expect(trace.map((e) => e.kind)).toEqual([
+        'run-start',
+        'prompt',
+        'run-end',
+      ])
+      expect(trace.every((e) => e.runId === 'fixed-run-1')).toBe(true)
+    })
+  })
+
+  it('is a no-op for tracing when tracing is disabled', async () => {
+    const model = streamingMock(['x'])
+    const { result } = renderHook(() => useAgent({ model, tools: [] }))
+    await act(async () => {
+      await result.current.run('hi')
+    })
+    expect(await readTrace()).toEqual([])
+  })
+})

--- a/src/hooks/use-agent.ts
+++ b/src/hooks/use-agent.ts
@@ -1,0 +1,231 @@
+/**
+ * §O — `useAgent` React hook.
+ *
+ * Thin wrapper over §N's `streamTrueAIAgentRun` that owns the
+ * `AbortController`, surfaces token / tool-call progress as React
+ * state, and (when enabled) records every transition into the §H
+ * `kvStore`-backed agent trace.
+ *
+ * The hook is intentionally narrow:
+ *   - No model selection logic — callers pass a `LanguageModel`.
+ *   - No history persistence — that is a chat-level concern.
+ *   - No retry policy — fail fast and let the UI show the error.
+ *
+ * Replaces the ad-hoc agent plumbing currently inlined in `App.tsx` /
+ * `App-Enhanced.tsx`. Those top-level shells sit at ~25% / ~30% line
+ * coverage *because* the agent state is inlined there; extracting it
+ * into a standalone hook gives us a coverable seam.
+ */
+
+import { useCallback, useRef, useState } from 'react'
+import {
+  streamTrueAIAgentRun,
+  type BuildTrueAIAgentOptions,
+} from '@/lib/agent/tool-loop-agent'
+import {
+  isTraceEnabled,
+  recordTraceEvent,
+} from '@/lib/agent/trace'
+
+export type AgentRunStatus = 'idle' | 'running' | 'aborted' | 'done' | 'error'
+
+export interface AgentToolEvent {
+  /** Stable id from the AI SDK so UIs can dedupe tool-result rows. */
+  id: string
+  name: string
+  /** Input as sent to the tool; undefined while still streaming. */
+  input?: unknown
+  /** Output once the tool has resolved; undefined while pending. */
+  output?: unknown
+  /** Error message if the tool rejected. */
+  error?: string
+}
+
+export interface UseAgentResult {
+  /** Current run status. `idle` until `run()` is called. */
+  status: AgentRunStatus
+  /** Concatenated assistant text accumulated so far this run. */
+  text: string
+  /** Tool-call rows in the order the model invoked them. */
+  toolEvents: AgentToolEvent[]
+  /** Last error message, if any. */
+  error: string | null
+  /** Start a new run. Aborts any in-flight run first. */
+  run: (goal: string) => Promise<void>
+  /** Abort the in-flight run. No-op when idle. */
+  abort: () => void
+}
+
+export interface UseAgentOptions extends BuildTrueAIAgentOptions {
+  /**
+   * Stable run id used to correlate trace events. When omitted, the
+   * hook generates a `crypto.randomUUID()` per call to `run()`.
+   */
+  runId?: string
+}
+
+/**
+ * React hook that drives a single agent run at a time. The returned
+ * `run(goal)` Promise resolves once the stream is fully drained (or
+ * the user calls `abort()`). All intermediate state is exposed as
+ * regular React state so a chat UI can re-render on every chunk.
+ */
+export function useAgent(opts: UseAgentOptions): UseAgentResult {
+  const [status, setStatus] = useState<AgentRunStatus>('idle')
+  const [text, setText] = useState('')
+  const [toolEvents, setToolEvents] = useState<AgentToolEvent[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const controllerRef = useRef<AbortController | null>(null)
+
+  const abort = useCallback(() => {
+    controllerRef.current?.abort()
+  }, [])
+
+  const run = useCallback(
+    async (goal: string) => {
+      controllerRef.current?.abort()
+      const controller = new AbortController()
+      controllerRef.current = controller
+      const runId = opts.runId ?? generateRunId()
+
+      setStatus('running')
+      setText('')
+      setToolEvents([])
+      setError(null)
+
+      const tracingOn = await isTraceEnabled()
+      if (tracingOn) {
+        await recordTraceEvent(runId, 'run-start', { goal })
+        await recordTraceEvent(runId, 'prompt', { text: goal })
+      }
+
+      try {
+        const result = streamTrueAIAgentRun(opts, {
+          goal,
+          abortSignal: controller.signal,
+        })
+
+        for await (const part of result.fullStream) {
+          if (controller.signal.aborted) break
+          await handlePart(part, {
+            tracingOn,
+            runId,
+            setText,
+            setToolEvents,
+          })
+        }
+
+        if (controller.signal.aborted) {
+          setStatus('aborted')
+          if (tracingOn) {
+            await recordTraceEvent(runId, 'run-end', { ok: false, aborted: true })
+          }
+          return
+        }
+
+        setStatus('done')
+        if (tracingOn) {
+          await recordTraceEvent(runId, 'run-end', { ok: true })
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        if (controller.signal.aborted) {
+          setStatus('aborted')
+          if (tracingOn) {
+            await recordTraceEvent(runId, 'run-end', { ok: false, aborted: true })
+          }
+          return
+        }
+        setError(message)
+        setStatus('error')
+        if (tracingOn) {
+          await recordTraceEvent(runId, 'error', { message })
+        }
+      } finally {
+        if (controllerRef.current === controller) {
+          controllerRef.current = null
+        }
+      }
+    },
+    [opts],
+  )
+
+  return { status, text, toolEvents, error, run, abort }
+}
+
+interface PartHandlerCtx {
+  tracingOn: boolean
+  runId: string
+  setText: (updater: (prev: string) => string) => void
+  setToolEvents: (updater: (prev: AgentToolEvent[]) => AgentToolEvent[]) => void
+}
+
+async function handlePart(part: unknown, ctx: PartHandlerCtx): Promise<void> {
+  if (typeof part !== 'object' || part === null) return
+  const p = part as { type?: string }
+  switch (p.type) {
+    case 'text-delta': {
+      // The AI SDK's user-facing fullStream emits `{ type: 'text-delta', text }`.
+      // Older versions used `delta`; accept both for forward/backward
+      // compatibility.
+      const tp = p as { text?: string; delta?: string }
+      const delta = tp.text ?? tp.delta ?? ''
+      ctx.setText((prev) => prev + delta)
+      return
+    }
+    case 'tool-call': {
+      const tc = p as { toolCallId?: string; toolName?: string; input?: unknown }
+      const id = tc.toolCallId ?? `tc-${Date.now()}`
+      const name = tc.toolName ?? '<unknown>'
+      ctx.setToolEvents((prev) => [
+        ...prev,
+        { id, name, input: tc.input },
+      ])
+      if (ctx.tracingOn) {
+        await recordTraceEvent(ctx.runId, 'tool-call', { name, input: tc.input })
+      }
+      return
+    }
+    case 'tool-result': {
+      const tr = p as { toolCallId?: string; toolName?: string; output?: unknown }
+      const id = tr.toolCallId
+      const name = tr.toolName ?? '<unknown>'
+      ctx.setToolEvents((prev) =>
+        prev.map((e) => (e.id === id ? { ...e, output: tr.output } : e)),
+      )
+      if (ctx.tracingOn) {
+        await recordTraceEvent(ctx.runId, 'tool-result', { name, output: tr.output })
+      }
+      return
+    }
+    case 'tool-error': {
+      const te = p as { toolCallId?: string; toolName?: string; error?: unknown }
+      const id = te.toolCallId
+      const name = te.toolName ?? '<unknown>'
+      const message =
+        te.error instanceof Error ? te.error.message : String(te.error ?? 'error')
+      ctx.setToolEvents((prev) =>
+        prev.map((e) => (e.id === id ? { ...e, error: message } : e)),
+      )
+      if (ctx.tracingOn) {
+        await recordTraceEvent(ctx.runId, 'error', { name, message })
+      }
+      return
+    }
+    default:
+      // Other parts (stream-start, response-metadata, finish, …) are
+      // not surfaced to the UI; the chat doesn't need them.
+      return
+  }
+}
+
+function generateRunId(): string {
+  // Browsers + jsdom both expose crypto.randomUUID(). Fall back to a
+  // timestamp+random hybrid for the few environments without it
+  // (some older WebViews); the trace uses runId for grouping only,
+  // not for security.
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `run-${Date.now()}-${Math.floor(Math.random() * 1e9).toString(36)}`
+}


### PR DESCRIPTION
## §O — `useAgent` React hook

Implements plan item §O. Adds a thin React hook over §N's `streamTrueAIAgentRun` so the chat UI can drop the inlined agent plumbing currently in `App.tsx` / `App-Enhanced.tsx` (those shells sit at ~25 / ~30 % line coverage *because* the agent state lives there).

### Surface

```ts
const { status, text, toolEvents, error, run, abort } = useAgent({ model, tools })
```

- `status` — `idle | running | aborted | done | error`
- `text` — concatenated assistant text accumulated so far
- `toolEvents` — ordered tool-call rows; `tool-result` folds into the matching call by `toolCallId`
- `run(goal)` aborts any in-flight run first
- `abort()` cancels via the per-run `AbortController`

### Trace integration (§H)

When tracing is enabled, the hook records run-start / prompt / tool-call / tool-result / tool-error / run-end / error events automatically. No-op when disabled — the hook itself stays opt-in to telemetry.

### Tests (4)

Status transitions, abort path with a stuck stream, trace recording when enabled, no-op when disabled. Total 74 passing across the agent + hook suite.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>