### PR TITLE
feat(ci): cross-CLI agent dispatchers — Aider + Codex parity (§J)

### DIFF
--- a/.github/workflows/aider-agent.yml
+++ b/.github/workflows/aider-agent.yml
@@ -1,0 +1,101 @@
+name: Aider Agent Dispatch
+
+# Mirror of copilot-agent.yml's custom-task path for users running the Aider
+# CLI (https://aider.chat). Inert until the repo owner configures an Aider
+# runner — this workflow only normalizes the task and surfaces it as a
+# structured issue labelled `aider-task` so the owner's Aider runner (local or
+# self-hosted) can pick it up.
+#
+# AGENTS.md (§A) is the portable contract; this workflow makes the dispatch
+# entry point match copilot-agent.yml so users on a different CLI don't have
+# to rebuild the task pipeline.
+
+on:
+  workflow_dispatch:
+    inputs:
+      task_description:
+        description: 'Task for the Aider agent to work on.'
+        required: true
+        default: ''
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  dispatch:
+    name: Dispatch task to Aider runner
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Ensure required labels exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "aider-task" --color "1d76db" \
+            --description "Task dispatched to Aider runner" --repo "$REPO" --force
+
+      - name: Dispatch task to Aider runner
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TASK: ${{ inputs.task_description }}
+          ACTOR: ${{ github.actor }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          DATE=$(date -u '+%Y-%m-%d')
+          printf '%s' "$TASK" > /tmp/task_desc.txt
+          TASK_CONTENT=$(cat /tmp/task_desc.txt)
+          SLUG=$(echo "$TASK_CONTENT" | tr '[:upper:]' '[:lower:]' \
+            | tr -cs 'a-z0-9' '-' | sed 's/--*/-/g' | cut -c1-40 | sed 's/-$//')
+
+          cat > /tmp/task_body.md <<BODY_EOF
+          ## Manual agent task dispatch (Aider)
+
+          | Field | Value |
+          |---|---|
+          | **Runner** | \`aider\` |
+          | **Requested by** | @${ACTOR} |
+          | **Date** | ${DATE} |
+          | **Run** | https://github.com/${REPO}/actions/runs/${RUN_ID} |
+
+          ### Task
+
+          ${TASK_CONTENT}
+
+          ### Constraints the fix MUST satisfy
+
+          - [ ] All existing unit tests still pass (\`npm test\`)
+          - [ ] \`npm run lint\` exits 0 (no new errors)
+          - [ ] \`npm run build:dev\` succeeds
+          - [ ] \`package.json\` overrides pins must not be weakened
+          - [ ] No telemetry, analytics, or third-party network calls added
+
+          ### Instructions for the Aider runner
+
+          1. Read \`AGENTS.md\` (the portable agent contract) and \`.github/copilot/LEARNINGS.md\` first.
+          2. Implement the requested change following all repo conventions.
+          3. Run \`npm run lint\`, \`npm run build:dev\`, and \`npm test\` before opening the PR.
+          4. Use branch name: \`aider/fix-${RUN_NUMBER}-${SLUG}\`
+          5. Fill in the \`## Lessons learned\` section of the PR description.
+          BODY_EOF
+
+          TITLE="[Auto] Aider task: $(echo "$TASK_CONTENT" | cut -c1-80)"
+          ISSUE_URL=$(gh issue create \
+            --repo "$REPO" \
+            --title "$TITLE" \
+            --body-file /tmp/task_body.md \
+            --label "aider-task")
+          echo "Created issue: $ISSUE_URL"
+
+          {
+            echo "## Aider Agent Dispatch"
+            echo ""
+            echo "Issue created (label \`aider-task\`): $ISSUE_URL"
+            echo ""
+            echo "Inert until an Aider runner is wired up. See AGENTS.md."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/codex-agent.yml
+++ b/.github/workflows/codex-agent.yml
@@ -1,0 +1,101 @@
+name: Codex Agent Dispatch
+
+# Mirror of copilot-agent.yml's custom-task path for users running the OpenAI
+# Codex CLI. Inert until the repo owner configures a Codex runner — this
+# workflow only normalizes the task and surfaces it as a structured issue
+# labelled `codex-task` so the owner's Codex runner (local or self-hosted)
+# can pick it up.
+#
+# AGENTS.md (§A) is the portable contract; this workflow makes the dispatch
+# entry point match copilot-agent.yml so users on a different CLI don't have
+# to rebuild the task pipeline.
+
+on:
+  workflow_dispatch:
+    inputs:
+      task_description:
+        description: 'Task for the Codex agent to work on.'
+        required: true
+        default: ''
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  dispatch:
+    name: Dispatch task to Codex runner
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Ensure required labels exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "codex-task" --color "0e8a16" \
+            --description "Task dispatched to Codex runner" --repo "$REPO" --force
+
+      - name: Dispatch task to Codex runner
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TASK: ${{ inputs.task_description }}
+          ACTOR: ${{ github.actor }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          DATE=$(date -u '+%Y-%m-%d')
+          printf '%s' "$TASK" > /tmp/task_desc.txt
+          TASK_CONTENT=$(cat /tmp/task_desc.txt)
+          SLUG=$(echo "$TASK_CONTENT" | tr '[:upper:]' '[:lower:]' \
+            | tr -cs 'a-z0-9' '-' | sed 's/--*/-/g' | cut -c1-40 | sed 's/-$//')
+
+          cat > /tmp/task_body.md <<BODY_EOF
+          ## Manual agent task dispatch (Codex)
+
+          | Field | Value |
+          |---|---|
+          | **Runner** | \`codex\` |
+          | **Requested by** | @${ACTOR} |
+          | **Date** | ${DATE} |
+          | **Run** | https://github.com/${REPO}/actions/runs/${RUN_ID} |
+
+          ### Task
+
+          ${TASK_CONTENT}
+
+          ### Constraints the fix MUST satisfy
+
+          - [ ] All existing unit tests still pass (\`npm test\`)
+          - [ ] \`npm run lint\` exits 0 (no new errors)
+          - [ ] \`npm run build:dev\` succeeds
+          - [ ] \`package.json\` overrides pins must not be weakened
+          - [ ] No telemetry, analytics, or third-party network calls added
+
+          ### Instructions for the Codex runner
+
+          1. Read \`AGENTS.md\` (the portable agent contract) and \`.github/copilot/LEARNINGS.md\` first.
+          2. Implement the requested change following all repo conventions.
+          3. Run \`npm run lint\`, \`npm run build:dev\`, and \`npm test\` before opening the PR.
+          4. Use branch name: \`codex/fix-${RUN_NUMBER}-${SLUG}\`
+          5. Fill in the \`## Lessons learned\` section of the PR description.
+          BODY_EOF
+
+          TITLE="[Auto] Codex task: $(echo "$TASK_CONTENT" | cut -c1-80)"
+          ISSUE_URL=$(gh issue create \
+            --repo "$REPO" \
+            --title "$TITLE" \
+            --body-file /tmp/task_body.md \
+            --label "codex-task")
+          echo "Created issue: $ISSUE_URL"
+
+          {
+            echo "## Codex Agent Dispatch"
+            echo ""
+            echo "Issue created (label \`codex-task\`): $ISSUE_URL"
+            echo ""
+            echo "Inert until a Codex runner is wired up. See AGENTS.md."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,13 @@ risk.
   [`.github/copilot/PROMPTS.md`](.github/copilot/PROMPTS.md)
 - Operator runbook:
   [`docs/AGENT_OPERATIONS.md`](docs/AGENT_OPERATIONS.md)
+- On-demand task dispatchers (workflow_dispatch, owner-only):
+  [`copilot-agent.yml`](.github/workflows/copilot-agent.yml),
+  [`aider-agent.yml`](.github/workflows/aider-agent.yml),
+  [`codex-agent.yml`](.github/workflows/codex-agent.yml). Each surfaces a
+  task as a structured issue with a runner-specific label
+  (`copilot-fix`, `aider-task`, `codex-task`). The Aider and Codex
+  dispatchers are inert until the owner wires up a corresponding runner.
 - Runtime / token / environment reference:
   [`AGENT_RUNTIME.md`](AGENT_RUNTIME.md) and
   [`.github/copilot/AGENT_RUNTIME.md`](.github/copilot/AGENT_RUNTIME.md)


### PR DESCRIPTION
## §J — Cross-CLI dispatcher parity

Implements plan item §J. Adds owner-only `workflow_dispatch` workflows that mirror `copilot-agent.yml`'s custom-task path for users running the **Aider** or **OpenAI Codex** CLIs.

### What

- `.github/workflows/aider-agent.yml` → opens an issue labelled `aider-task`.
- `.github/workflows/codex-agent.yml` → opens an issue labelled `codex-task`.
- AGENTS.md: new 'On-demand task dispatchers' bullet linking all three workflows so the portable agent contract (§A) round-trips to the dispatcher entry points.

### Why

§A made the *contract* portable across Copilot / Claude Code / Codex / Cursor / Aider, but the only on-demand task dispatcher today is Copilot-specific. Users on a different CLI had to rebuild the issue/branch convention pipeline themselves. These two workflows give them the same entry point — they're inert until a runner is wired up, but they preserve the convention (constraints checklist, AGENTS.md + LEARNINGS.md reading order, runner-specific branch names `aider/fix-…` / `codex/fix-…`).

### Scope

- Custom-task path only. The full-scan path stays centralised in `copilot-agent.yml` + the scheduled audit; duplicating it would create three competing issue trackers.
- No new permissions beyond `contents: read` + `issues: write`.
- YAML validated locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>