### PR TITLE
feat(mcp): zero-dep stdio MCP server bridging local-first tools (§E)

### DIFF
--- a/docs/AGENT_MCP_SERVER.md
+++ b/docs/AGENT_MCP_SERVER.md
@@ -1,0 +1,72 @@
+# MCP server (`scripts/mcp-server.mjs`)
+
+**Plan item §E.** A minimal Model Context Protocol server that vends
+TrueAI's local-first tool registry to any MCP-aware client (Claude
+Desktop, Cursor, Continue, …) over stdio JSON-RPC 2.0.
+
+## Why no `@modelcontextprotocol/sdk` dependency?
+
+The on-the-wire MCP protocol is small enough to implement directly
+(~50 LOC of JSON-RPC framing). Pulling in the SDK would expand
+TrueAI's supply-chain surface for a marginal feature whose primary
+audience is users who already run an MCP-aware IDE separately.
+
+## Tools exposed
+
+All tools are zero-network, zero-eval, no IO beyond the host clock.
+This server intentionally does **not** vend network- or
+credential-gated tools — MCP clients should call hosted LLMs
+themselves; TrueAI's MCP server only provides safe local primitives.
+
+| Tool          | Description                                                 |
+| ------------- | ----------------------------------------------------------- |
+| `currentTime` | ISO-8601 timestamp + IANA time zone                         |
+| `mathEval`    | Local arithmetic eval (`+ - * / ( )`, decimals; 256-char cap) |
+
+`kvStoreLookup` is intentionally **not** exposed: the KV store lives
+in IndexedDB inside the running app, and an out-of-process MCP server
+can't read it. We don't pretend otherwise.
+
+## Wiring it into an MCP client
+
+### Claude Desktop
+
+Add to `~/.config/Claude/claude_desktop_config.json` (Linux) or
+`~/Library/Application Support/Claude/claude_desktop_config.json`
+(macOS):
+
+```json
+{
+  "mcpServers": {
+    "trueai": {
+      "command": "node",
+      "args": ["/abs/path/to/TrueAI/scripts/mcp-server.mjs"]
+    }
+  }
+}
+```
+
+### Cursor / Continue / generic MCP clients
+
+Same shape — `command: node`, `args: [absolute path to script]`.
+
+## Scripts
+
+```bash
+npm run mcp:server   # start the server (stdio JSON-RPC; daemon mode)
+npm run mcp:smoke    # 6-case smoke test through a child process
+```
+
+## Protocol coverage
+
+Implemented JSON-RPC methods:
+
+- `initialize` — returns `serverInfo`, `protocolVersion`, `capabilities.tools`
+- `notifications/initialized` (no response)
+- `tools/list`
+- `tools/call` — returns `{ content: [{ type: 'text', text }], isError }`
+- `ping`
+
+Unknown methods → `-32601` (Method not found). Bad JSON → `-32700`.
+Unknown tool → `-32602`. Tool errors are returned as `isError: true`
+on the result envelope, per the MCP spec.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,6 +25,16 @@ export default [
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {
+    files: ['scripts/**/*.{js,mjs,cjs}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+  {
     files: ['src/**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2020,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,6 +24,16 @@ export default [
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {
+    files: ['scripts/**/*.{js,mjs,cjs}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+  {
     files: ['src/**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2020,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
         "check:model-policy": "node scripts/check-model-policy.mjs",
         "check:tool-docs": "node scripts/gen-tool-docs.mjs --check",
         "docs:tools": "node scripts/gen-tool-docs.mjs",
+        "mcp:server": "node scripts/mcp-server.mjs",
+        "mcp:smoke": "node scripts/mcp-server.smoke.mjs",
         "compact:learnings": "node scripts/compact-learnings.mjs",
         "agent:replay": "node scripts/agent-replay.mjs",
         "optimize": "vite optimize",

--- a/scripts/mcp-server.mjs
+++ b/scripts/mcp-server.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+/**
+ * TrueAI — Minimal MCP server (stdio, JSON-RPC 2.0)
+ *
+ * Bridges the project's local-first tool registry (§B) to any MCP-aware
+ * client (Claude Desktop, Cursor, Continue, etc.) without pulling in the
+ * `@modelcontextprotocol/sdk` package — the on-the-wire protocol is small
+ * enough to implement directly and we'd rather not weaken supply-chain
+ * surface for a marginal feature.
+ *
+ * Wiring example for Claude Desktop's `claude_desktop_config.json`:
+ *
+ *     {
+ *       "mcpServers": {
+ *         "trueai": {
+ *           "command": "node",
+ *           "args": ["/abs/path/to/TrueAI/scripts/mcp-server.mjs"]
+ *         }
+ *       }
+ *     }
+ *
+ * Tools exposed (all zero-network, no eval, no IO beyond the host's clock):
+ *
+ *   - currentTime  → { iso, timestamp, timeZone }
+ *   - mathEval     → { expression, result }
+ *
+ * Notes:
+ *   - kvStoreLookup is intentionally NOT exposed: the KV store lives in
+ *     IndexedDB inside the running app; an out-of-process MCP server
+ *     cannot read it and we don't want to pretend otherwise.
+ *   - Network/credential-gated tools are refused on principle — MCP
+ *     clients should call the hosted LLM themselves; this server only
+ *     vends safe local primitives.
+ */
+
+import { createInterface } from 'node:readline'
+
+const SERVER_NAME = 'trueai-local'
+const SERVER_VERSION = '0.1.0'
+const PROTOCOL_VERSION = '2024-11-05'
+
+// ---------- Tool implementations (mirror src/lib/agent/tool-registry.ts) ----
+
+function currentTime() {
+  const now = new Date()
+  return {
+    iso: now.toISOString(),
+    timestamp: now.getTime(),
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
+  }
+}
+
+function mathEval({ expression }) {
+  if (typeof expression !== 'string') {
+    throw new Error('mathEval: expression must be a string')
+  }
+  const cleaned = expression.replace(/\s+/g, '')
+  if (cleaned.length === 0 || cleaned.length > 256) {
+    throw new Error('mathEval: expression length out of range (1..256)')
+  }
+  if (!/^[0-9+\-*/().]+$/.test(cleaned)) {
+    throw new Error('mathEval: expression contains unsupported characters')
+  }
+  let i = 0
+  const parseNumber = () => {
+    const start = i
+    while (i < cleaned.length && /[0-9.]/.test(cleaned[i])) i++
+    if (start === i) throw new Error('mathEval: expected a number')
+    const n = Number(cleaned.slice(start, i))
+    if (!Number.isFinite(n)) throw new Error('mathEval: invalid number')
+    return n
+  }
+  const parseFactor = () => {
+    if (cleaned[i] === '+') { i++; return parseFactor() }
+    if (cleaned[i] === '-') { i++; return -parseFactor() }
+    if (cleaned[i] === '(') {
+      i++
+      const v = parseExpression()
+      if (cleaned[i] !== ')') throw new Error('mathEval: missing closing parenthesis')
+      i++
+      return v
+    }
+    return parseNumber()
+  }
+  const parseTerm = () => {
+    let v = parseFactor()
+    while (i < cleaned.length && (cleaned[i] === '*' || cleaned[i] === '/')) {
+      const op = cleaned[i++]
+      const r = parseFactor()
+      if (op === '/') {
+        if (r === 0) throw new Error('mathEval: division by zero')
+        v = v / r
+      } else v = v * r
+    }
+    return v
+  }
+  const parseExpression = () => {
+    let v = parseTerm()
+    while (i < cleaned.length && (cleaned[i] === '+' || cleaned[i] === '-')) {
+      const op = cleaned[i++]
+      const r = parseTerm()
+      v = op === '+' ? v + r : v - r
+    }
+    return v
+  }
+  const value = parseExpression()
+  if (i !== cleaned.length) throw new Error('mathEval: unexpected trailing input')
+  if (!Number.isFinite(value)) throw new Error('mathEval: non-finite result')
+  return { expression, result: value }
+}
+
+const TOOLS = [
+  {
+    name: 'currentTime',
+    description:
+      'Return the current date and time in ISO-8601 form, plus the resolved IANA time zone.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+    handler: () => currentTime(),
+  },
+  {
+    name: 'mathEval',
+    description:
+      'Evaluate a basic arithmetic expression with +, -, *, /, parentheses, and decimals. Local, no eval(), no network.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        expression: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 256,
+          description: 'Arithmetic expression, e.g. "(2 + 3) * 4".',
+        },
+      },
+      required: ['expression'],
+      additionalProperties: false,
+    },
+    handler: (args) => mathEval(args ?? {}),
+  },
+]
+
+// ---------- JSON-RPC framing -----------------------------------------------
+
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + '\n')
+}
+
+function ok(id, result) { send({ jsonrpc: '2.0', id, result }) }
+function fail(id, code, message, data) {
+  send({ jsonrpc: '2.0', id, error: { code, message, ...(data ? { data } : {}) } })
+}
+
+function handle(req) {
+  const { id, method, params } = req
+  const isNotification = id === undefined || id === null
+
+  switch (method) {
+    case 'initialize':
+      return ok(id, {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: { tools: { listChanged: false } },
+        serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
+      })
+
+    case 'notifications/initialized':
+    case 'initialized':
+      return // notification, no response
+
+    case 'tools/list':
+      return ok(id, {
+        tools: TOOLS.map(({ name, description, inputSchema }) => ({
+          name, description, inputSchema,
+        })),
+      })
+
+    case 'tools/call': {
+      const name = params?.name
+      const args = params?.arguments ?? {}
+      const tool = TOOLS.find((t) => t.name === name)
+      if (!tool) {
+        return fail(id, -32602, `Unknown tool: ${name}`)
+      }
+      try {
+        const value = tool.handler(args)
+        return ok(id, {
+          content: [{ type: 'text', text: JSON.stringify(value) }],
+          isError: false,
+        })
+      } catch (err) {
+        return ok(id, {
+          content: [{ type: 'text', text: String(err?.message ?? err) }],
+          isError: true,
+        })
+      }
+    }
+
+    case 'ping':
+      return ok(id, {})
+
+    default:
+      if (!isNotification) fail(id, -32601, `Method not found: ${method}`)
+  }
+}
+
+// ---------- Wire up stdio ---------------------------------------------------
+
+const rl = createInterface({ input: process.stdin, terminal: false })
+rl.on('line', (line) => {
+  const trimmed = line.trim()
+  if (!trimmed) return
+  let req
+  try {
+    req = JSON.parse(trimmed)
+  } catch {
+    fail(null, -32700, 'Parse error')
+    return
+  }
+  try {
+    handle(req)
+  } catch (err) {
+    fail(req?.id ?? null, -32603, `Internal error: ${String(err?.message ?? err)}`)
+  }
+})
+
+rl.on('close', () => process.exit(0))

--- a/scripts/mcp-server.smoke.mjs
+++ b/scripts/mcp-server.smoke.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Smoke test for scripts/mcp-server.mjs — drives the JSON-RPC stdio
+ * protocol through a child process and asserts the responses for
+ * initialize / tools/list / tools/call (success + error paths).
+ */
+
+import { spawn } from 'node:child_process'
+import { createInterface } from 'node:readline'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import assert from 'node:assert/strict'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const SERVER = join(__dirname, 'mcp-server.mjs')
+
+function startServer() {
+  const proc = spawn(process.execPath, [SERVER], {
+    stdio: ['pipe', 'pipe', 'inherit'],
+  })
+  const lines = []
+  const waiters = []
+  const rl = createInterface({ input: proc.stdout })
+  rl.on('line', (line) => {
+    if (waiters.length) waiters.shift()(line)
+    else lines.push(line)
+  })
+  const next = () =>
+    new Promise((resolve) => {
+      if (lines.length) resolve(lines.shift())
+      else waiters.push(resolve)
+    })
+  const send = (msg) => proc.stdin.write(JSON.stringify(msg) + '\n')
+  return { proc, send, next }
+}
+
+async function main() {
+  const { proc, send, next } = startServer()
+
+  send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+  const init = JSON.parse(await next())
+  assert.equal(init.id, 1)
+  assert.equal(init.result.serverInfo.name, 'trueai-local')
+  assert.ok(init.result.capabilities.tools)
+
+  send({ jsonrpc: '2.0', method: 'notifications/initialized' })
+
+  send({ jsonrpc: '2.0', id: 2, method: 'tools/list' })
+  const list = JSON.parse(await next())
+  assert.equal(list.id, 2)
+  const names = list.result.tools.map((t) => t.name).sort()
+  assert.deepEqual(names, ['currentTime', 'mathEval'])
+
+  send({
+    jsonrpc: '2.0', id: 3, method: 'tools/call',
+    params: { name: 'mathEval', arguments: { expression: '(2 + 3) * 4' } },
+  })
+  const ok = JSON.parse(await next())
+  assert.equal(ok.id, 3)
+  assert.equal(ok.result.isError, false)
+  const payload = JSON.parse(ok.result.content[0].text)
+  assert.equal(payload.result, 20)
+
+  send({
+    jsonrpc: '2.0', id: 4, method: 'tools/call',
+    params: { name: 'mathEval', arguments: { expression: 'os.exit()' } },
+  })
+  const refused = JSON.parse(await next())
+  assert.equal(refused.id, 4)
+  assert.equal(refused.result.isError, true)
+  assert.match(refused.result.content[0].text, /unsupported characters/)
+
+  send({
+    jsonrpc: '2.0', id: 5, method: 'tools/call',
+    params: { name: 'noSuchTool', arguments: {} },
+  })
+  const unknown = JSON.parse(await next())
+  assert.equal(unknown.id, 5)
+  assert.equal(unknown.error.code, -32602)
+
+  send({ jsonrpc: '2.0', id: 6, method: 'tools/call',
+    params: { name: 'currentTime', arguments: {} } })
+  const ct = JSON.parse(await next())
+  const ctPayload = JSON.parse(ct.result.content[0].text)
+  assert.match(ctPayload.iso, /^\d{4}-\d{2}-\d{2}T/)
+  assert.equal(typeof ctPayload.timestamp, 'number')
+
+  proc.stdin.end()
+  await new Promise((r) => proc.on('exit', r))
+  console.log('mcp-server smoke test: 6/6 OK')
+}
+
+main().catch((err) => {
+  console.error('mcp-server smoke test FAILED:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
## §E — MCP server

Implements plan item §E. Adds a **minimal, zero-dependency** stdio MCP server (`scripts/mcp-server.mjs`) that bridges TrueAI's local-first tool registry (§B) to any MCP-aware IDE / client.

### What

- `scripts/mcp-server.mjs` — JSON-RPC 2.0 over stdin/stdout. Implements `initialize`, `notifications/initialized`, `tools/list`, `tools/call`, `ping`. Spec-correct error codes.
- Tools exposed: **`currentTime`** + **`mathEval`**. `mathEval` shares the same recursive-descent parser as the in-app registry (`+ - * / ( )`, decimals, 256-char cap, no eval).
- `scripts/mcp-server.smoke.mjs` — 6-case end-to-end test against a spawned child.
- npm scripts: `mcp:server`, `mcp:smoke`.
- `docs/AGENT_MCP_SERVER.md` — wiring snippets for Claude Desktop / Cursor and rationale.

### Intentional non-features

- **No** `@modelcontextprotocol/sdk` dependency — the on-the-wire protocol is small enough to implement in ~50 LOC of framing; pulling in the SDK would expand supply-chain surface for marginal value.
- **No** `kvStoreLookup` exposure — the KV store is IndexedDB inside the running app; an out-of-process server can't read it. We don't fake it.
- **No** network/credential-gated tools — MCP clients call hosted LLMs themselves; this server only vends safe local primitives.

### Side-improvement (tightly coupled)

Scoped Node globals to `scripts/**` in both eslint configs. Every existing script had the same `'process' is not defined` false-positive pattern (lint only scoped browser globals to `src/**`). **Net lint: 307 → 131 errors** (-176; zero new findings from MCP files).

### Constraints honoured

- ✅ No new dependencies added
- ✅ `package.json` overrides untouched
- ✅ No telemetry / network calls added
- ✅ Smoke test 6/6 green; `tsc --noEmit` clean

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>