### PR TITLE
test: cover workflow-runtime edge branches

### DIFF
--- a/src/lib/workflow-runtime.test.ts
+++ b/src/lib/workflow-runtime.test.ts
@@ -189,6 +189,195 @@ describe('runWorkflow', () => {
     expect(r.steps.filter(s => s.nodeId === 'b').length).toBe(3)
   })
 
+  it('treats an empty / whitespace decision condition as truthy', async () => {
+    const executeTool = vi.fn(async () => ({ success: true, output: 'ok' }))
+    const wf = makeWorkflow({
+      nodes: [
+        { id: 's', type: 'start', position: { x: 0, y: 0 }, data: { label: 'start' } },
+        { id: 'd', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'noop', condition: '   ' } },
+        { id: 'tT', type: 'tool', position: { x: 0, y: 0 }, data: { label: 'T', toolName: 'datetime' } },
+        { id: 'tF', type: 'tool', position: { x: 0, y: 0 }, data: { label: 'F', toolName: 'datetime' } },
+        { id: 'e', type: 'end', position: { x: 0, y: 0 }, data: { label: 'end' } },
+      ],
+      edges: [
+        { id: 'e0', source: 's', target: 'd' },
+        { id: 'eT', source: 'd', target: 'tT', label: 'true' },
+        { id: 'eF', source: 'd', target: 'tF', label: 'false' },
+        { id: 'e1', source: 'tT', target: 'e' },
+        { id: 'e2', source: 'tF', target: 'e' },
+      ],
+    })
+    const r = await runWorkflow(wf, { toolExecutor: { executeTool } })
+    expect(r.steps.map(s => s.nodeId)).toContain('tT')
+  })
+
+  it('treats a malformed decision condition as truthy (eval throws → catch)', async () => {
+    const executeTool = vi.fn(async () => ({ success: true, output: 'ok' }))
+    const wf = makeWorkflow({
+      nodes: [
+        { id: 's', type: 'start', position: { x: 0, y: 0 }, data: { label: 'start' } },
+        { id: 'd', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'bad', condition: '((' } },
+        { id: 'tT', type: 'tool', position: { x: 0, y: 0 }, data: { label: 'T', toolName: 'datetime' } },
+        { id: 'tF', type: 'tool', position: { x: 0, y: 0 }, data: { label: 'F', toolName: 'datetime' } },
+        { id: 'e', type: 'end', position: { x: 0, y: 0 }, data: { label: 'end' } },
+      ],
+      edges: [
+        { id: 'e0', source: 's', target: 'd' },
+        { id: 'eT', source: 'd', target: 'tT', label: 'true' },
+        { id: 'eF', source: 'd', target: 'tF', label: 'false' },
+        { id: 'e1', source: 'tT', target: 'e' },
+        { id: 'e2', source: 'tF', target: 'e' },
+      ],
+    })
+    const r = await runWorkflow(wf, { toolExecutor: { executeTool } })
+    expect(r.steps.map(s => s.nodeId)).toContain('tT')
+  })
+
+  it('falls back to ordinal edge picking when decision edges are unlabelled', async () => {
+    const executeTool = vi.fn(async () => ({ success: true, output: 'ok' }))
+    const wf = makeWorkflow({
+      nodes: [
+        { id: 's', type: 'start', position: { x: 0, y: 0 }, data: { label: 'start' } },
+        { id: 'd', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'no', condition: 'false' } },
+        { id: 'tA', type: 'tool', position: { x: 0, y: 0 }, data: { label: 'A', toolName: 'datetime' } },
+        { id: 'tB', type: 'tool', position: { x: 0, y: 0 }, data: { label: 'B', toolName: 'datetime' } },
+        { id: 'e', type: 'end', position: { x: 0, y: 0 }, data: { label: 'end' } },
+      ],
+      edges: [
+        { id: 'e0', source: 's', target: 'd' },
+        // No labels: falsy branch should pick edges[1] = tB.
+        { id: 'eA', source: 'd', target: 'tA' },
+        { id: 'eB', source: 'd', target: 'tB' },
+        { id: 'e1', source: 'tA', target: 'e' },
+        { id: 'e2', source: 'tB', target: 'e' },
+      ],
+    })
+    const r = await runWorkflow(wf, { toolExecutor: { executeTool } })
+    expect(r.steps.map(s => s.nodeId)).toContain('tB')
+  })
+
+  it('fails a tool node missing toolName', async () => {
+    const wf = makeWorkflow({
+      nodes: [
+        { id: 's', type: 'start', position: { x: 0, y: 0 }, data: { label: 'start' } },
+        { id: 't', type: 'tool', position: { x: 0, y: 0 }, data: { label: 'x' } },
+      ],
+      edges: [{ id: 'e1', source: 's', target: 't' }],
+    })
+    const r = await runWorkflow(wf)
+    expect(r.status).toBe('error')
+    expect(r.error).toMatch(/missing toolName/)
+  })
+
+  it('returns error result when an agent node llm rejects', async () => {
+    const llm = vi.fn(async () => {
+      throw new Error('llm boom')
+    })
+    const wf = makeWorkflow({
+      nodes: [
+        { id: 's', type: 'start', position: { x: 0, y: 0 }, data: { label: 'start' } },
+        { id: 'a', type: 'agent', position: { x: 0, y: 0 }, data: { label: 'A', agentId: 'a-1' } },
+      ],
+      edges: [{ id: 'e1', source: 's', target: 'a' }],
+    })
+    const r = await runWorkflow(wf, {
+      llm,
+      resolveAgent: id => ({ id, model: 'm' }),
+    })
+    expect(r.status).toBe('error')
+    expect(r.error).toMatch(/llm boom/)
+  })
+
+  it('passes through unknown node types via the default switch arm', async () => {
+    const wf = makeWorkflow({
+      nodes: [
+        { id: 's', type: 'start', position: { x: 0, y: 0 }, data: { label: 'start' } },
+        // Cast to unknown node type to exercise the default branch.
+        { id: 'x', type: 'mystery' as unknown as 'tool', position: { x: 0, y: 0 }, data: { label: 'mystery' } },
+        { id: 'e', type: 'end', position: { x: 0, y: 0 }, data: { label: 'end' } },
+      ],
+      edges: [
+        { id: 'e1', source: 's', target: 'x' },
+        { id: 'e2', source: 'x', target: 'e' },
+      ],
+    })
+    const r = await runWorkflow(wf)
+    expect(r.status).toBe('completed')
+    expect(r.steps.map(s => s.nodeId)).toEqual(['s', 'x', 'e'])
+  })
+
+  it('uses globalThis.spark.llm by default when no llm dep is provided', async () => {
+    const sparkLlm = vi.fn(async (_p: string, _m: string) => 'spark out')
+    const g = globalThis as unknown as { spark?: { llm?: unknown } }
+    const prevSpark = g.spark
+    g.spark = { ...(prevSpark ?? {}), llm: sparkLlm }
+    try {
+      const wf = makeWorkflow({
+        nodes: [
+          { id: 's', type: 'start', position: { x: 0, y: 0 }, data: { label: 'start' } },
+          { id: 'a', type: 'agent', position: { x: 0, y: 0 }, data: { label: 'A' } },
+          { id: 'e', type: 'end', position: { x: 0, y: 0 }, data: { label: 'end' } },
+        ],
+        edges: [
+          { id: 'e1', source: 's', target: 'a' },
+          { id: 'e2', source: 'a', target: 'e' },
+        ],
+      })
+      const r = await runWorkflow(wf)
+      expect(r.status).toBe('completed')
+      expect(sparkLlm).toHaveBeenCalledTimes(1)
+      expect(r.results.a).toBe('spark out')
+    } finally {
+      g.spark = prevSpark
+    }
+  })
+
+  it('errors out when no llm dep and no globalThis.spark.llm is available', async () => {
+    const g = globalThis as unknown as { spark?: { llm?: unknown } }
+    const prevSpark = g.spark
+    g.spark = { ...(prevSpark ?? {}), llm: undefined }
+    try {
+      const wf = makeWorkflow({
+        nodes: [
+          { id: 's', type: 'start', position: { x: 0, y: 0 }, data: { label: 'start' } },
+          { id: 'a', type: 'agent', position: { x: 0, y: 0 }, data: { label: 'A' } },
+        ],
+        edges: [{ id: 'e1', source: 's', target: 'a' }],
+      })
+      const r = await runWorkflow(wf)
+      expect(r.status).toBe('error')
+      expect(r.error).toMatch(/spark\.llm undefined/)
+    } finally {
+      g.spark = prevSpark
+    }
+  })
+
+  it('errors when an edge points to a missing node id (dangling edge)', async () => {
+    const wf = makeWorkflow({
+      nodes: [
+        { id: 's', type: 'start', position: { x: 0, y: 0 }, data: { label: 'start' } },
+      ],
+      edges: [{ id: 'e1', source: 's', target: 'ghost' }],
+    })
+    const r = await runWorkflow(wf)
+    expect(r.status).toBe('error')
+    expect(r.error).toMatch(/dangling edge/)
+  })
+
+  it('completes cleanly when a non-end node has no outgoing edges', async () => {
+    const executeTool = vi.fn(async () => ({ success: true, output: 'last' }))
+    const wf = makeWorkflow({
+      nodes: [
+        { id: 's', type: 'start', position: { x: 0, y: 0 }, data: { label: 'start' } },
+        { id: 't', type: 'tool', position: { x: 0, y: 0 }, data: { label: 'x', toolName: 'datetime' } },
+      ],
+      edges: [{ id: 'e1', source: 's', target: 't' }],
+    })
+    const r = await runWorkflow(wf, { toolExecutor: { executeTool } })
+    expect(r.status).toBe('completed')
+    expect(r.results.t).toBe('last')
+  })
+
   it('invokes onStep for every executed node', async () => {
     const executeTool = vi.fn(async () => ({ success: true, output: 'ok' }))
     const onStep = vi.fn()


### PR DESCRIPTION
Adds 10 tests targeting uncovered branches in workflow-runtime.ts (evalCondition empty/catch, pickDecisionEdge ordinal fallback, tool missing toolName, agent llm rejection, default switch arm, default llm spark/error paths, dangling edge, no-outgoing-edges).

workflow-runtime.ts 85.85→**97.17** lines. All-files 84.58→**84.69** stmts · 76.85→**77.07** branch · 78.9→**78.93** funcs · 86.74→**86.84** lines.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>