### PR TITLE
chore: ratchet coverage thresholds to 84.5/77/79/86.5

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -159,17 +159,17 @@ export default defineConfig({
         // `dismissSuggestion`, and the `if (!behavior)` early returns
         // in `generateSuggestions` / `getPredictedNextAction` /
         // `getRecommendedFeatures`).
-        // **Threshold ratchet (post-PRs #102/#104/#105/#106):** all-files
-        // now sits at 84.21 stmts · 76.15 branch · 78.71 funcs · 86.38
-        // lines (218/218 files, 3107/3107 tests). Bumped from
-        // 83.5 / 75 / 77 / 85 to 84 / 76 / 78 / 86 to lock in the gains
-        // from PRs #102 (PerfProfile/QuickActions/useAgent), #104
-        // (agent-tools error paths), #105 (diagnostics edge branches),
-        // and #106 (analytics rollups + day bucketing).
-        lines: 86,
-        functions: 78,
-        branches: 76,
-        statements: 84,
+        // **Threshold ratchet (post-PRs #108/#109/#110/#111):** all-files
+        // now sits at 84.8 stmts · 77.2 branch · 79.09 funcs · 86.91
+        // lines after the auto-optimizer (#108), performance-scanner
+        // (#109), workflow-runtime (#110), and use-data-prefetcher
+        // (#111) coverage chunks. Bumped from 84 / 76 / 78 / 86 to
+        // 84.5 / 77 / 79 / 86.5 to lock in the gains while leaving
+        // ~0.3-0.4pp room for the next mid-band push.
+        lines: 86.5,
+        functions: 79,
+        branches: 77,
+        statements: 84.5,
       },
     },
   },


### PR DESCRIPTION
Locks in this-cycle gains from PRs #108-#111. New thresholds vs actual:

- statements: 84 → **84.5** (actual 84.8)
- branches:   76 → **77** (actual 77.2)
- functions:  78 → **79** (actual 79.09)
- lines:      86 → **86.5** (actual 86.91)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>