### PR TITLE
test(coverage): PerformanceWrapper saveData + observer (81→~99)

### DIFF
--- a/src/components/PerformanceWrapper.test.tsx
+++ b/src/components/PerformanceWrapper.test.tsx
@@ -51,4 +51,53 @@ describe('PerformanceWrapper', () => {
     render(<PerformanceWrapper><div>content</div></PerformanceWrapper>)
     expect(screen.getByText('content')).toBeInTheDocument()
   })
+
+  it('adds save-data-mode class when capabilities.saveData is true', async () => {
+    document.body.classList.remove('save-data-mode')
+    const { useAutoPerformanceOptimization } = await import('@/hooks/use-auto-performance')
+    vi.mocked(useAutoPerformanceOptimization).mockReturnValue({
+      capabilities: { tier: 'high', cores: 8, memory: 16, gpu: '', connection: '4g', saveData: true, batteryLevel: 1, charging: true },
+      isOptimized: true,
+      settings: null,
+      isLowEnd: false,
+      isMidTier: false,
+      isHighEnd: true,
+      shouldReduceMotion: false
+    })
+    render(<PerformanceWrapper><div>sd</div></PerformanceWrapper>)
+    expect(document.body.classList.contains('save-data-mode')).toBe(true)
+  })
+
+  it('warns on long PerformanceObserver tasks and falls back when observe throws', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {})
+    let capturedCb: ((list: { getEntries: () => Array<{ duration: number }> }) => void) | null = null
+    class FakePO {
+      constructor(cb: (list: { getEntries: () => Array<{ duration: number }> }) => void) {
+        capturedCb = cb
+      }
+      observe() { throw new Error('not supported') }
+      disconnect() {}
+    }
+    const originalPO = (window as unknown as { PerformanceObserver: unknown }).PerformanceObserver
+    ;(window as unknown as { PerformanceObserver: unknown }).PerformanceObserver = FakePO
+    const { useAutoPerformanceOptimization } = await import('@/hooks/use-auto-performance')
+    vi.mocked(useAutoPerformanceOptimization).mockReturnValue({
+      capabilities: { tier: 'mid', cores: 4, memory: 8, gpu: '', connection: '4g', saveData: false, batteryLevel: 1, charging: true },
+      isOptimized: true,
+      settings: null,
+      isLowEnd: false,
+      isMidTier: true,
+      isHighEnd: false,
+      shouldReduceMotion: false
+    })
+    render(<PerformanceWrapper><div>po</div></PerformanceWrapper>)
+    expect(capturedCb).not.toBeNull()
+    capturedCb!({ getEntries: () => [{ duration: 120 }, { duration: 10 }] })
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/Long task detected: 120/))
+    expect(info).toHaveBeenCalledWith('Long task monitoring not available')
+    ;(window as unknown as { PerformanceObserver: unknown }).PerformanceObserver = originalPO
+    warn.mockRestore()
+    info.mockRestore()
+  })
 })


### PR DESCRIPTION
Covers save-data class branch and PerformanceObserver long-task warn + observe-throws fallback.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>